### PR TITLE
fix game auto-start bug

### DIFF
--- a/app/lib/sms-games/controllers/logicGameStart.js
+++ b/app/lib/sms-games/controllers/logicGameStart.js
@@ -73,7 +73,7 @@ function autoStartGame(gameId) {
       if (err) {
         logger.error('Error in running auto-start game function for gameId: ' + gameId + ' Error: ' + err);
       }
-      else {
+      else if (doc.game_started !== true) {
 
         var isMultiplayer = false;
         var betas = doc.betas;


### PR DESCRIPTION
#### What's this PR do?
Simple fix to a bug: beta version of game (id 201) restarts automatically at auto-start game time delay, regardless if game has already begun. 

We add a check to make sure that the game hasn't already begun. 

#### How should this be manually tested?
Using Postman, I've created 1) games where no one has joined, to confirm that auto-start works, and 2) games where people have joined, to confirm that the game doesn't restart. 

#### What are the relevant tickets?
Closes #385.