### PR TITLE
Ryan's playbook config + logger fix

### DIFF
--- a/app/config/smsConfigsLoader.js
+++ b/app/config/smsConfigsLoader.js
@@ -8,6 +8,7 @@ var connectionOperations = require('./connectionOperations')
     , rootRequire('app/lib/ds-routing/config/yesNoPathsConfigModel')(connectionConfig)
     , rootRequire('app/lib/sms-games/config/competitiveStoriesConfigModel')(connectionConfig)
     ]
+  , logger = rootRequire('app/lib/logger')
   ;
 
 var configObject = {}

--- a/app/lib/ds-routing/config/start-campaign-transitions.json
+++ b/app/lib/ds-routing/config/start-campaign-transitions.json
@@ -148,5 +148,11 @@
         "__comments": "Search For Specs 2014",
         "optin": 174571,
         "optout": 130821
+    },
+    {
+        "_id": 11867,
+        "__comments": "Ryan's Playbooks 2014",
+        "optin": 174359,
+        "optout": 130683
     }
 ]


### PR DESCRIPTION
This fixes two things:
- `logger` was undefined in smsConfigsLoader and so it'd throw an exception when it'd try to log errors
- and then the error it was trying to log was that a Ryan's playbook config was missing

###### Background info
This is the error the server was throwing:
```
[01/08 12:58:45 EST][err] ReferenceError: logger is not defined
[01/08 12:58:45 EST][err]     at EventEmitter.app.getConfig (/opt/run/snapshot/package/app/config/smsConfigsLoader.js:66:3)
[01/08 12:58:45 EST][err]     at MCRouting.campaignTransition (/opt/run/snapshot/package/app/lib/ds-routing/controllers/MCRouting.js:65:30)
[01/08 12:58:45 EST][err]     at module.exports (/opt/run/snapshot/package/app/lib/ds-routing/index.js:26:13)
[01/08 12:58:45 EST][err]     at Layer.handle [as handle_request] (/opt/run/snapshot/package/node_modules/express/lib/router/layer.js:82:5)
[01/08 12:58:45 EST][err]     at next (/opt/run/snapshot/package/node_modules/express/lib/router/route.js:100:13)
[01/08 12:58:45 EST][err]     at Route.dispatch (/opt/run/snapshot/package/node_modules/express/lib/router/route.js:81:3)
[01/08 12:58:45 EST][err]     at Layer.handle [as handle_request] (/opt/run/snapshot/package/node_modules/express/lib/router/layer.js:82:5)
[01/08 12:58:45 EST][err]     at /opt/run/snapshot/package/node_modules/express/lib/router/index.js:235:24
[01/08 12:58:45 EST][err]     at Function.proto.process_params (/opt/run/snapshot/package/node_modules/express/lib/router/index.js:313:12)
[01/08 12:58:45 EST][err]     at Function.cls_wrapProcessParams [as process_params] (/opt/run/snapshot/package/node_modules/newrelic/lib/instrumentation/express.js:185:29)
```