### PR TITLE
Report Back Retry

### DIFF
--- a/app/lib/ds-content-api/index.js
+++ b/app/lib/ds-content-api/index.js
@@ -316,10 +316,10 @@ function campaignsReportback(rbData, callback) {
  */
 function isCampaignsReportbackError(response, body) {
   if (body && body.length > 0 && body[0] != false) {
-    return true;
+    return false;
   }
   else {
-    return false;
+    return true;
   }
 }
 

--- a/app/lib/ds-content-api/index.js
+++ b/app/lib/ds-content-api/index.js
@@ -1,6 +1,7 @@
 var request = require('request')
   , crypto = require('crypto')
   , logger = rootRequire('app/lib/logger')
+  , RequestRetry = require('node-request-retry')
   ;
 
 var BASE_URL;
@@ -288,8 +289,6 @@ function campaignsReportback(rbData, callback) {
   };
 
   var options = {
-    url: BASE_URL + '/campaigns/' + nid + '/reportback',
-    method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'Accept': 'application/json',
@@ -305,12 +304,35 @@ function campaignsReportback(rbData, callback) {
     _callback = onCampaignsReportback.bind({customCallback: callback});
   }
 
-  request(options, _callback);
+  var requestRetry = new RequestRetry();
+  requestRetry.setRetryConditions([400, 408, 500, isCampaignsReportbackError]);
+
+  var url = BASE_URL + '/campaigns/' + nid + '/reportback';
+  requestRetry.post(url, options, _callback);
 }
 
+/**
+ * Evaluates a report back submission's response and determines if it's valid or not.
+ */
+function isCampaignsReportbackError(response, body) {
+  if (body && body.length > 0 && body[0] != false) {
+    return true;
+  }
+  else {
+    return false;
+  }
+}
+
+/**
+ * Report back submission callback.
+ */
 function onCampaignsReportback(err, response, body) {
   if (err) {
     logger.error(err);
+  }
+
+  if (isCampaignsReportbackError(response, body)) {
+    err = 'Invalid body received from report back response';
   }
 
   if (typeof this.customCallback === 'function') {

--- a/app/lib/reportback/index.js
+++ b/app/lib/reportback/index.js
@@ -335,11 +335,19 @@ function submitReportBack(uid, doc, data) {
   };
 
   dscontentapi.campaignsReportback(rbData, function(err, response, body) {
-    if (!err && body && body.length > 0) {
-      logger.info('Successfully submitted report back. rbid: ' + body[0]);
+    if (err) {
+      logger.error(err);
+    }
+    else if (body && body.length > 0) {
+      if (body[0] == false) {
+        logger.error('Error when submitting report back.', response);
+      }
+      else {
+        logger.info('Successfully submitted report back. rbid: ' + body[0]);
 
-      // Remove the report back doc when complete
-      model.remove({phone: data.phone, campaign: data.campaignConfig.endpoint}).exec();
+        // Remove the report back doc when complete
+        model.remove({phone: data.phone, campaign: data.campaignConfig.endpoint}).exec();
+      }
     }
   });
 }

--- a/app/lib/reportback/test/reportback.test.js
+++ b/app/lib/reportback/test/reportback.test.js
@@ -9,8 +9,12 @@ function test() {
   var TEST_PHONE = '15555555555';
   var TEST_CAMPAIGN_CONFIG = app.getConfig('reportback', 'test', 'endpoint');
 
-  var createTestDoc = function() {
-    model.create({phone: TEST_PHONE, campaign: TEST_CAMPAIGN_CONFIG.endpoint});
+  var createTestDoc = function(done) {
+    model.create({phone: TEST_PHONE, campaign: TEST_CAMPAIGN_CONFIG.endpoint}, function(err, doc) {
+      if (doc) {
+        done();
+      }
+    });
   };
 
   var removeTestDoc = function() {

--- a/mobilecommons/mobilecommons.js
+++ b/mobilecommons/mobilecommons.js
@@ -71,7 +71,7 @@ exports.profile_update = function(phone, optInPathId, customFields) {
   };
 
   var requestRetry = new RequestRetry();
-  requestRetry.setRetryCodes([400, 408, 500]);
+  requestRetry.setRetryConditions([400, 408, 500]);
   requestRetry.post(url, postData, callback);
 };
 
@@ -87,7 +87,7 @@ exports.optin = function(args) {
   var betaOptin = args.betaOptin || 0;
   var callback;
   var requestRetry = new RequestRetry();
-  requestRetry.setRetryCodes([400, 408, 500]);
+  requestRetry.setRetryConditions([400, 408, 500]);
 
   // Need at least these in order to continue
   if (alphaPhone == null || alphaOptin <= 0)
@@ -242,7 +242,7 @@ exports.optout = function(args) {
   };
 
   var requestRetry = new RequestRetry();
-  requestRetry.setRetryCodes([400, 408, 500]);
+  requestRetry.setRetryConditions([400, 408, 500]);
   requestRetry.post(url, payload, callback);
 };
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "mongoose": "~3.8.8",
     "mysql": "2.1.x",
     "newrelic": "1.11.x",
-    "node-request-retry": "^0.0.1",
+    "node-request-retry": "^1.0.0",
     "path": "~0.4.9",
     "q": "^1.0.1",
     "request": "2.34.x",


### PR DESCRIPTION
#### What's this PR do?
Report back submissions will be retried up to 3 times if the response comes back with an error response of some sort. An error is either a response with status code 400, 408, 500 (these are just ones we've commonly seen elsewhere) or a body with a value == FALSE.

Other things:
- Logging the error when a response has a body == FALSE
- Updated the report back test to hopefully fix the random timeout issues we were seeing on tests

#### Where should the reviewer start?
###### ds-content-api/index.js
Report back submissions are now done with the node-request-retry module. This allows us to retry failed requests and also set a custom callback (`isCampaignsReportBackError`) that determines if a response is valid or not.

###### reportback.test.js
The changes here make `createTestDoc` wait until the doc is created before continuing to the next step.

#### How should this be manually tested?
- `$ npm update`
- `$ npm test`
- Ensure you have appropriate values for `DS_CONTENT_API_*` in your environment to login and submit to the staging server.
- `$ node server.js`
- Use Postman to submit requests to test the report back flow.

#### Any background context?
It was seen a couple times that report backs submitted through the DS content API would return FALSE. But then subsequent submissions seemed to fix it. So this is sort of a brute-force way of making fixing it.

#### What are the relevant tickets?
Close #402