### PR TITLE
Config name refactoring

### DIFF
--- a/app/config/smsConfigsLoader.js
+++ b/app/config/smsConfigsLoader.js
@@ -1,3 +1,16 @@
+/**
+ * Globally-accessible object of config names.
+ */
+app.ConfigName = {
+  CAMPAIGN_START: 'campaign_start',
+  CAMPAIGN_TRANSITIONS: 'start_campaign_transition',
+  COMPETITIVE_STORIES: 'competitive_story',
+  DONORSCHOOSE: 'donorschoose',
+  REPORTBACK: 'reportback',
+  TIPS: 'tips',
+  YES_NO_PATHS: 'yes_no_path'
+};
+
 var connectionOperations = require('./connectionOperations')
   , connectionConfig = require('./connectionConfig')
   , configModelArray = [
@@ -77,19 +90,6 @@ app.getConfig = function(modelName, id, key) {
     }
   }
   logger.error('Unable to find requested config document for config model: ' + modelName + ' with id: ' + id);
-};
-
-/**
- * Globally-accessible object of config names.
- */
-app.ConfigName = {
-  CAMPAIGN_START: 'campaign_start',
-  CAMPAIGN_TRANSITIONS: 'start_campaign_transition',
-  COMPETITIVE_STORIES: 'competitive_story',
-  DONORSCHOOSE: 'donorschoose',
-  REPORTBACK: 'reportback',
-  TIPS: 'tips',
-  YES_NO_PATHS: 'yes_no_path'
 };
 
 module.exports = smsConfigsLoader;

--- a/app/config/smsConfigsLoader.js
+++ b/app/config/smsConfigsLoader.js
@@ -84,12 +84,12 @@ app.getConfig = function(modelName, id, key) {
  */
 app.ConfigName = {
   CAMPAIGN_START: 'campaign_start',
-  CAMPAIGN_TRANSITIONS: 'start_campaign_transitions',
-  COMPETITIVE_STORIES: 'competitive_stories',
+  CAMPAIGN_TRANSITIONS: 'start_campaign_transition',
+  COMPETITIVE_STORIES: 'competitive_story',
   DONORSCHOOSE: 'donorschoose',
   REPORTBACK: 'reportback',
   TIPS: 'tips',
-  YES_NO_PATHS: 'yes_no_paths'
+  YES_NO_PATHS: 'yes_no_path'
 };
 
 module.exports = smsConfigsLoader;

--- a/app/config/smsConfigsLoader.js
+++ b/app/config/smsConfigsLoader.js
@@ -77,6 +77,19 @@ app.getConfig = function(modelName, id, key) {
     }
   }
   logger.error('Unable to find requested config document for config model: ' + modelName + ' with id: ' + id);
-}
+};
+
+/**
+ * Globally-accessible object of config names.
+ */
+app.ConfigName = {
+  CAMPAIGN_START: 'campaign_start',
+  CAMPAIGN_TRANSITIONS: 'start_campaign_transitions',
+  COMPETITIVE_STORIES: 'competitive_stories',
+  DONORSCHOOSE: 'donorschoose',
+  REPORTBACK: 'reportback',
+  TIPS: 'tips',
+  YES_NO_PATHS: 'yes_no_paths'
+};
 
 module.exports = smsConfigsLoader;

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -73,7 +73,7 @@ DonorsChooseDonationController.prototype.findProject = function(request, respons
     return;
   }
 
-  var config = app.getConfig('donorschoose', request.query.id);
+  var config = app.getConfig(app.ConfigName.DONORSCHOOSE, request.query.id);
 
   // Checking to see if the location param is a zip code or a state,
   // and assigning query params accordingly. 
@@ -197,7 +197,7 @@ DonorsChooseDonationController.prototype.retrieveEmail = function(request, respo
   };
   var self = this;
   var req = request; 
-  var config = app.getConfig('donorschoose', request.query.id);
+  var config = app.getConfig(app.ConfigName.DONORSCHOOSE, request.query.id);
 
   // Populates the updateObject with the user's email only 
   // if it's non-obscene and is actually an email. Otherwise,
@@ -358,7 +358,7 @@ DonorsChooseDonationController.prototype.submitDonation = function(apiInfoObject
  */
 DonorsChooseDonationController.prototype.retrieveFirstName = function(request, response) {
 
-  var config = app.getConfig('donorschoose', request.query.id);
+  var config = app.getConfig(app.ConfigName.DONORSCHOOSE, request.query.id);
   var userSubmittedName = smsHelper.getFirstWord(request.body.args);
   var req = request;
 
@@ -411,7 +411,7 @@ DonorsChooseDonationController.prototype.retrieveLocation = function(request, re
 
   response.send();
 
-  var config = app.getConfig('donorschoose', request.query.id);
+  var config = app.getConfig(app.ConfigName.DONORSCHOOSE, request.query.id);
   var location = smsHelper.getFirstWord(request.body.args);
 
   if (TYPE_OF_LOCATION_WE_ARE_QUERYING_FOR == 'zip') {

--- a/app/lib/donations/models/donorschooseConfigModel.js
+++ b/app/lib/donations/models/donorschooseConfigModel.js
@@ -36,5 +36,5 @@ var donorschooseConfigSchema = new mongoose.Schema({
 })
 
 module.exports = function(connection) {
-  return connection.model('donorschoose', donorschooseConfigSchema, 'donorschoose'); // Third param explicitly setting the name of the collection. 
+  return connection.model(app.ConfigName.DONORSCHOOSE, donorschooseConfigSchema, 'donorschoose'); // Third param explicitly setting the name of the collection. 
 }

--- a/app/lib/ds-routing/config/campaignStartConfigModel.js
+++ b/app/lib/ds-routing/config/campaignStartConfigModel.js
@@ -29,5 +29,5 @@ var campaignStartConfigSchema = new mongoose.Schema({
 })
 
 module.exports = function(connection) {
-  return connection.model('campaign_start', campaignStartConfigSchema, 'campaign_start'); // Third param explicitly setting the name of the collection. 
+  return connection.model(app.ConfigName.CAMPAIGN_START, campaignStartConfigSchema, 'campaign_start'); // Third param explicitly setting the name of the collection. 
 }

--- a/app/lib/ds-routing/config/startCampaignTransitionsConfigModel.js
+++ b/app/lib/ds-routing/config/startCampaignTransitionsConfigModel.js
@@ -23,5 +23,5 @@ var startCampaignTransitionsConfigSchema = new mongoose.Schema({
 })
 
 module.exports = function(connection) {
-  return connection.model('start_campaign_transition', startCampaignTransitionsConfigSchema);
+  return connection.model(app.ConfigName.CAMPAIGN_TRANSITIONS, startCampaignTransitionsConfigSchema);
 }

--- a/app/lib/ds-routing/config/startCampaignTransitionsConfigModel.js
+++ b/app/lib/ds-routing/config/startCampaignTransitionsConfigModel.js
@@ -23,5 +23,5 @@ var startCampaignTransitionsConfigSchema = new mongoose.Schema({
 })
 
 module.exports = function(connection) {
-  return connection.model('start_campaign_transitions', startCampaignTransitionsConfigSchema);
+  return connection.model('start_campaign_transition', startCampaignTransitionsConfigSchema);
 }

--- a/app/lib/ds-routing/config/tipsConfigModel.js
+++ b/app/lib/ds-routing/config/tipsConfigModel.js
@@ -21,5 +21,5 @@ var tipsConfigSchema = new mongoose.Schema({
 })
 
 module.exports = function(connection) {
-  return connection.model('tips', tipsConfigSchema);
+  return connection.model(app.ConfigName.TIPS, tipsConfigSchema);
 }

--- a/app/lib/ds-routing/config/yesNoPathsConfigModel.js
+++ b/app/lib/ds-routing/config/yesNoPathsConfigModel.js
@@ -25,5 +25,5 @@ var yesNoPathsConfigSchema = new mongoose.Schema({
 })
 
 module.exports = function(connection) {
-  return connection.model('yes_no_paths', yesNoPathsConfigSchema);
+  return connection.model('yes_no_path', yesNoPathsConfigSchema);
 }

--- a/app/lib/ds-routing/config/yesNoPathsConfigModel.js
+++ b/app/lib/ds-routing/config/yesNoPathsConfigModel.js
@@ -25,5 +25,5 @@ var yesNoPathsConfigSchema = new mongoose.Schema({
 })
 
 module.exports = function(connection) {
-  return connection.model('yes_no_path', yesNoPathsConfigSchema);
+  return connection.model(app.ConfigName.YES_NO_PATHS, yesNoPathsConfigSchema);
 }

--- a/app/lib/ds-routing/controllers/MCRouting.js
+++ b/app/lib/ds-routing/controllers/MCRouting.js
@@ -21,7 +21,7 @@ MCRouting.prototype.yesNoGateway = function(request, response) {
 
   var args = request.body.args.trim().toLowerCase();
   var incomingOptIn = parseInt(request.body.opt_in_path_id);
-  var path = app.getConfig('yes_no_paths', incomingOptIn)
+  var path = app.getConfig(app.ConfigName.YES_NO_PATHS, incomingOptIn)
 
   // If no path can be found, early out.
   if (path === undefined) {
@@ -62,7 +62,7 @@ MCRouting.prototype.campaignTransition = function(request, response) {
   }
 
   var mdataId = parseInt(request.body.mdata_id);
-  var transitionConfig = app.getConfig('start_campaign_transitions', mdataId);
+  var transitionConfig = app.getConfig(app.ConfigName.CAMPAIGN_TRANSITIONS, mdataId);
 
   if (typeof(transitionConfig) !== 'undefined'
       && typeof(transitionConfig.optin) !== 'undefined'
@@ -101,7 +101,7 @@ MCRouting.prototype.handleStartCampaignResponse = function(request, response) {
 
   var optinPathId = request.body.opt_in_path_id;
 
-  var startConfig = app.getConfig('campaign_start', optinPathId)
+  var startConfig = app.getConfig(app.ConfigName.CAMPAIGN_START, optinPathId)
 
   // Get the config set that matches this opt_in_path_id.
   // Error out if there's no matching config.

--- a/app/lib/ds-routing/controllers/Tips.js
+++ b/app/lib/ds-routing/controllers/Tips.js
@@ -37,7 +37,7 @@ Tips.prototype.deliverTips = function(request, response, mdataOverride) {
   }
 
   // Decide tip name based on the mdata id.
-  var tipConfig = app.getConfig('tips', mdataId);
+  var tipConfig = app.getConfig(app.ConfigName.TIPS, mdataId);
 
   // Config error checking
   if (typeof(tipConfig) === 'undefined'

--- a/app/lib/reportback/index.js
+++ b/app/lib/reportback/index.js
@@ -22,7 +22,7 @@ router.post('/:campaign', function(request, response) {
   
   // Check that we have a config setup for this campaign
   campaign = request.params.campaign;
-  campaignConfig = app.getConfig('reportback', campaign, 'endpoint');
+  campaignConfig = app.getConfig(app.ConfigName.REPORTBACK, campaign, 'endpoint');
 
   if (typeof campaignConfig !== 'undefined') {
     phone = request.body.phone;

--- a/app/lib/reportback/reportbackConfigModel.js
+++ b/app/lib/reportback/reportbackConfigModel.js
@@ -30,5 +30,5 @@ var rbSchema = new mongoose.Schema({
 });
 
 module.exports = function(connection) {
-  return connection.model('reportback', rbSchema);
+  return connection.model(app.ConfigName.REPORTBACK, rbSchema);
 }

--- a/app/lib/reportback/test/reportback.test.js
+++ b/app/lib/reportback/test/reportback.test.js
@@ -7,7 +7,7 @@ var assert = require('assert')
 
 function test() {
   var TEST_PHONE = '15555555555';
-  var TEST_CAMPAIGN_CONFIG = app.getConfig('reportback', 'test', 'endpoint');
+  var TEST_CAMPAIGN_CONFIG = app.getConfig(app.ConfigName.REPORTBACK, 'test', 'endpoint');
 
   var createTestDoc = function(done) {
     model.create({phone: TEST_PHONE, campaign: TEST_CAMPAIGN_CONFIG.endpoint}, function(err, doc) {

--- a/app/lib/sms-games/config/competitiveStoriesConfigModel.js
+++ b/app/lib/sms-games/config/competitiveStoriesConfigModel.js
@@ -59,5 +59,5 @@ var competitiveStoriesConfigSchema = new mongoose.Schema({
 })
 
 module.exports = function(connection) {
-  return connection.model('competitive_stories', competitiveStoriesConfigSchema);
+  return connection.model('competitive_story', competitiveStoriesConfigSchema, 'competitive_stories');
 }

--- a/app/lib/sms-games/config/competitiveStoriesConfigModel.js
+++ b/app/lib/sms-games/config/competitiveStoriesConfigModel.js
@@ -59,5 +59,5 @@ var competitiveStoriesConfigSchema = new mongoose.Schema({
 })
 
 module.exports = function(connection) {
-  return connection.model('competitive_story', competitiveStoriesConfigSchema, 'competitive_stories');
+  return connection.model(app.ConfigName.COMPETITIVE_STORIES, competitiveStoriesConfigSchema, 'competitive_stories');
 }

--- a/app/lib/sms-games/controllers/SGCompetitiveStoryController.js
+++ b/app/lib/sms-games/controllers/SGCompetitiveStoryController.js
@@ -72,7 +72,7 @@ SGCompetitiveStoryController.prototype.createGame = function(request, response) 
     storyId = request.query.story_id;
   }
 
-  gameConfig = app.getConfig('competitive_stories', storyId)
+  gameConfig = app.getConfig(app.ConfigName.COMPETITIVE_STORIES, storyId)
 
   if (typeof gameConfig === 'undefined') {
     response.status(406).send('Game config not setup for story ID: ' + storyId);

--- a/app/lib/sms-games/controllers/gameMessageHelpers.js
+++ b/app/lib/sms-games/controllers/gameMessageHelpers.js
@@ -228,7 +228,7 @@ function endGameFromPlayerExit(playerDocs) {
     for (var i = 0; i < docs.length; i++) {
 
       var gameDoc = docs[i];
-      var gameConfig = app.getConfig('competitive_stories', gameDoc.story_id);
+      var gameConfig = app.getConfig(app.ConfigName.COMPETITIVE_STORIES, gameDoc.story_id);
 
       // Skip games that have already ended.
       var skipGame = false;

--- a/app/lib/sms-games/controllers/logicBetaJoin.js
+++ b/app/lib/sms-games/controllers/logicBetaJoin.js
@@ -16,7 +16,7 @@ var emitter = rootRequire('app/eventEmitter')
  */
 module.exports = function(request, doc) {
   var joiningBetaPhone = request.body.phone;
-  var gameConfig = app.getConfig('competitive_stories', doc.story_id)
+  var gameConfig = app.getConfig(app.ConfigName.COMPETITIVE_STORIES, doc.story_id)
 
   // If the game's already started, notify the user and exit.
   if (doc.game_started || doc.game_ended) {

--- a/app/lib/sms-games/controllers/logicGameStart.js
+++ b/app/lib/sms-games/controllers/logicGameStart.js
@@ -23,7 +23,7 @@ module.exports = {
  * @return Game document, updated with the requisite state changes.
  */
 function startGame(gameDoc) {
-  var gameConfig = app.getConfig('competitive_stories', gameDoc.story_id)
+  var gameConfig = app.getConfig(app.ConfigName.COMPETITIVE_STORIES, gameDoc.story_id)
   // Get the starting opt in path from the game config.
   var startMessage = gameConfig.story_start_oip;
 

--- a/app/lib/sms-games/controllers/logicUserAction.js
+++ b/app/lib/sms-games/controllers/logicUserAction.js
@@ -36,7 +36,7 @@ module.exports = function(request, doc) {
   }
 
   // Get the story config.
-  var gameConfig = app.getConfig('competitive_stories', doc.story_id)
+  var gameConfig = app.getConfig(app.ConfigName.COMPETITIVE_STORIES, doc.story_id)
 
   // Check if user response is valid.
   var choiceIndex = -1;
@@ -160,7 +160,7 @@ function sendEndMessagesUpdateReturnGameDoc(level, gameDoc) {
 
   // Send group the end level message.
   var endLevelGroupKey = level + '-GROUP';
-  var gameConfig = app.getConfig('competitive_stories', gameDoc.story_id)
+  var gameConfig = app.getConfig(app.ConfigName.COMPETITIVE_STORIES, gameDoc.story_id)
   var groupOptin = message.end.level.group(endLevelGroupKey, gameConfig, gameDoc);
   for (var i = 0; i < gameDoc.players_current_status.length; i++) {
     var playerPhone = gameDoc.players_current_status[i].phone;  

--- a/test/BullyText.js
+++ b/test/BullyText.js
@@ -20,7 +20,7 @@ describe('Bully Text game being played:', function() {
   var betaPhone1 = '5555550202';
   var betaPhone2 = '5555550203';
   var storyId = 100;
-  var gameConfig = app.getConfig('competitive_stories', storyId)
+  var gameConfig = app.getConfig(app.ConfigName.COMPETITIVE_STORIES, storyId)
 
   before('instantiating game controller, dummy response', testHelper.gameAppSetup);
 

--- a/test/EndGameFromUserExit.js
+++ b/test/EndGameFromUserExit.js
@@ -29,7 +29,7 @@ describe('Testing end game from user exit by creating two Science Sleuth games',
   var betaPhone4 = '5555550206';
 
   var storyId = 101;
-  var gameConfig = app.getConfig('competitive_stories', storyId)
+  var gameConfig = app.getConfig(app.ConfigName.COMPETITIVE_STORIES, storyId)
 
   before('instantiating game controller, dummy response', testHelper.gameAppSetup);
 

--- a/test/GameAlphaStart.js
+++ b/test/GameAlphaStart.js
@@ -21,7 +21,7 @@ describe('Alpha-Starting a Bully Text game:', function() {
   var betaPhone1 = '5555550102';
   var betaPhone2 = '5555550103';
   var storyId = 100;
-  var gameConfig = app.getConfig('competitive_stories', storyId)
+  var gameConfig = app.getConfig(app.ConfigName.COMPETITIVE_STORIES, storyId)
 
   before('instantiating game controller, dummy response', testHelper.gameAppSetup);
 
@@ -208,7 +208,7 @@ describe('Alpha-Starting a Bully Text game with first names:', function() {
   var betaName1 = 'beta_name_1';
   var betaName2 = 'beta_name_2';
   var storyId = 100;
-  var gameConfig = app.getConfig('competitive_stories', storyId)
+  var gameConfig = app.getConfig(app.ConfigName.COMPETITIVE_STORIES, storyId)
 
   before('instantiating game controller, dummy response', testHelper.gameAppSetup);
 

--- a/test/ScienceSleuth.js
+++ b/test/ScienceSleuth.js
@@ -20,7 +20,7 @@ describe('Science Sleuth game being played:', function() {
   var betaPhone1 = '5555550202';
   var betaPhone2 = '5555550203';
   var storyId = 101;
-  var gameConfig = app.getConfig('competitive_stories', storyId)
+  var gameConfig = app.getConfig(app.ConfigName.COMPETITIVE_STORIES, storyId)
 
   before('instantiating game controller, dummy response', testHelper.gameAppSetup);
 

--- a/test/ds-routing.js
+++ b/test/ds-routing.js
@@ -172,7 +172,7 @@ describe('ds-routing tests', function() {
         emitter.on(emitter.events.mcOptinTest, function(payload) {
           emitter.removeAllListeners(emitter.events.mcOptinTest);
 
-          var expected = app.getConfig('tips', 10673).optins;
+          var expected = app.getConfig(app.ConfigName.TIPS, 10673).optins;
           if (expected.indexOf(payload.form.opt_in_path) >= 0) {
             done();
           }
@@ -198,7 +198,7 @@ describe('ds-routing tests', function() {
         emitter.on(emitter.events.mcOptinTest, function(payload) {
           emitter.removeAllListeners(emitter.events.mcOptinTest);
 
-          var expected = app.getConfig('tips', 10663).optins;
+          var expected = app.getConfig(app.ConfigName.TIPS, 10663).optins;
           if (expected.indexOf(payload.form.opt_in_path) >= 0) {
             done();
           }
@@ -224,7 +224,7 @@ describe('ds-routing tests', function() {
         emitter.on(emitter.events.mcOptinTest, function(payload) {
           emitter.removeAllListeners(emitter.events.mcOptinTest);
 
-          var expected = app.getConfig('tips', 10243).optins;
+          var expected = app.getConfig(app.ConfigName.TIPS, 10243).optins;
           if (expected.indexOf(payload.form.opt_in_path) >= 0) {
             done();
           }
@@ -283,7 +283,7 @@ describe('ds-routing tests', function() {
       emitter.on(emitter.events.mcOptinTest, function(payload) {
         emitter.removeAllListeners(emitter.events.mcOptinTest);
 
-        var expected = app.getConfig('tips', 9521).optins;
+        var expected = app.getConfig(app.ConfigName.TIPS, 9521).optins;
         if (expected.indexOf(payload.form.opt_in_path) >= 0) {
           done();
         }


### PR DESCRIPTION
#### What's this PR do?
This is a minor refactor that defines config model names in a single location at `app.ConfigName`. When getting configs now, instead of using hardcoded strings, we use object properties. Also changed some model names from their plural to singular forms.

#### Where should the reviewer start?
- `smsConfigsLoader.js`: Model names defined here
- `*ConfigModel.js`: Plural names changed to singular
- Everything else: Changing from using hardcoded string to app.ConfigName

#### How did I test?
I tested by running `$ npm test` and sending requests to sms-multiplayer-game, reportback, and ds-routing endpoints to ensure they responded with valid responses.

#### What are the relevant tickets?
Closes #389

@tongxiang 