### PR TITLE
Reportback Caption

### DIFF
--- a/app/lib/ds-content-api/index.js
+++ b/app/lib/ds-content-api/index.js
@@ -283,6 +283,7 @@ function campaignsReportback(rbData, callback) {
   var nid = rbData.nid;
   var body = {
     uid: rbData.uid,
+    caption: rbData.caption,
     quantity: rbData.quantity,
     why_participated: rbData.why_participated,
     file_url: rbData.file_url

--- a/app/lib/reportback/index.js
+++ b/app/lib/reportback/index.js
@@ -101,6 +101,9 @@ function handleUserResponse(doc, data) {
   if (!doc.photo) {
     receivePhoto(doc, data);
   }
+  else if (!doc.caption) {
+    receiveCaption(doc, data);
+  }
   else if (!doc.quantity) {
     receiveQuantity(doc, data);
   }
@@ -132,8 +135,30 @@ function receivePhoto(doc, data) {
         }
       });
 
-    mobilecommons.profile_update(data.phone, data.campaignConfig.message_quantity);
+    mobilecommons.profile_update(data.phone, data.campaignConfig.message_caption);
   }
+}
+
+/**
+ * Process request for user who is sending the caption for the photo.
+ *
+ * @param doc
+ *   User's report back document
+ * @param data
+ *   Data from the user's request
+ */
+function receiveCaption(doc, data) {
+  var answer = data.args;
+  model.update(
+    {phone: data.phone},
+    {'$set': {caption: answer}},
+    function(err, num, raw) {
+      if (!err) {
+        emitter.emit(emitter.events.reportbackModelUpdate);
+      }
+    });
+
+  mobilecommons.profile_update(data.phone, data.campaignConfig.message_quantity);
 }
 
 /**

--- a/app/lib/reportback/index.js
+++ b/app/lib/reportback/index.js
@@ -354,6 +354,7 @@ function submitReportBack(uid, doc, data) {
   var rbData = {
     nid: data.campaignConfig.campaign_nid,
     uid: uid,
+    caption: doc.caption,
     quantity: doc.quantity,
     why_participated: doc.why_important,
     file_url: doc.photo

--- a/app/lib/reportback/index.js
+++ b/app/lib/reportback/index.js
@@ -389,6 +389,7 @@ if (process.env.NODE_ENV === 'test') {
   module.exports.findDocument = findDocument;
   module.exports.onDocumentFound = onDocumentFound;
   module.exports.handleUserResponse = handleUserResponse;
+  module.exports.receiveCaption = receiveCaption;
   module.exports.receivePhoto = receivePhoto;
   module.exports.receiveQuantity = receiveQuantity;
   module.exports.receiveWhyImportant = receiveWhyImportant;

--- a/app/lib/reportback/reportbackConfigModel.js
+++ b/app/lib/reportback/reportbackConfigModel.js
@@ -22,6 +22,9 @@ var rbSchema = new mongoose.Schema({
   // Mobile Commons opt-in path ID for when the MMS response doesn't contain a photo
   message_not_a_photo: Number,
 
+  // Mobile Commons opt-in path ID to ask for photo caption
+  message_caption: Number,
+
   // Mobile Commons opt-in path ID to ask for quantity
   message_quantity: Number,
 

--- a/app/lib/reportback/test/reportback.test.js
+++ b/app/lib/reportback/test/reportback.test.js
@@ -97,7 +97,7 @@ function test() {
 
     before(createTestDoc);
 
-    it('should respond with the "quantity" message', function(done) {
+    it('should respond with the "caption" message', function(done) {
       var mcEventDone = false;
       var rbEventDone = false;
       function onSuccessfulEvent(evt) {
@@ -116,7 +116,7 @@ function test() {
       // Check if correct user is subscribed to correct opt-in path
       emitter.on(emitter.events.mcProfileUpdateTest, function(evtData) {
         if (evtData.form.phone_number == testData.phone &&
-            evtData.form.opt_in_path_id == TEST_CAMPAIGN_CONFIG.message_quantity) {
+            evtData.form.opt_in_path_id == TEST_CAMPAIGN_CONFIG.message_caption) {
           onSuccessfulEvent(emitter.events.mcProfileUpdateTest);
         }
         else {


### PR DESCRIPTION
#### Important!
We'll need to update the campaigns on Mobile Commons that are actively receiving report backs before pushing this to production. We should also test on staging before pushing to prod. Trello card to remind us is here: https://trello.com/c/CC8rbPaz/168-sms-report-backs-with-captions

#### What's this PR do?
During the report back flow, users will be asked an additional question to provide a photo caption. The order now goes: `photo -> caption -> quantity -> why -> complete`.

#### Where should the reviewer start?
- `app/lib/ds-content-api/index.js`: adds a caption field to be submitted with the reportback request
- `app/lib/reportback/reportbackConfigModel.js`: adds a property for us to configure for the caption opt-in path
- `app/lib/reportback/index.js`: The meat of everything. Works pretty much like how we receive the quantity and send the next message to ask for why. Here we're just dropping in the caption message and receiving in between the photo receiving and quantity message.
- `app/lib/reportback/test/reportback.test.js`: tests modeled after the other tests already done

#### How should this be manually tested?
`$ npm test` and also tested by submitting to my local box with Postman.

#### What are the relevant tickets?
Closes #406