### PR TITLE
adding player names to the game invite process

### DIFF
--- a/app/lib/sms-games/controllers/SGCompetitiveStoryController.js
+++ b/app/lib/sms-games/controllers/SGCompetitiveStoryController.js
@@ -193,11 +193,7 @@ SGCompetitiveStoryController.prototype.createGame = function(request, response) 
 
     // We opt users into these initial opt in paths only if the game type is NOT solo. 
     if (self.createdGameDoc.game_type !== 'solo') {
-      name.addPlayerNamesToAlpha(self.createdGameDoc);
-      message.group(self.createdGameDoc.alpha_phone,
-        gameConfig.alpha_wait_oip,
-        betaOptInArray,
-        gameConfig.beta_join_ask_oip);
+      name.alphaInvite(gameConfig, self.createdGameDoc);
     }
 
   },

--- a/app/lib/sms-games/controllers/SGCompetitiveStoryController.js
+++ b/app/lib/sms-games/controllers/SGCompetitiveStoryController.js
@@ -16,6 +16,7 @@ var smsHelper = rootRequire('app/lib/smsHelpers')
   , betaJoinLogic = require('./logicBetaJoin')
   , alphaStartLogic = require('./logicAlphaStart')
   , start = require('./logicGameStart')
+  , name = require('./playerNameHelpers')
   ;
 
 // Maximum number of players that can be invited into a game.
@@ -102,7 +103,7 @@ SGCompetitiveStoryController.prototype.createGame = function(request, response) 
       gameDoc.betas[idx] = {};
       gameDoc.betas[idx].invite_accepted = false;
       gameDoc.betas[idx].phone = phone;
-      gameDoc.betas[idx].name = request.body['beta_first_name_' + i] || null;
+      gameDoc.betas[idx].name = request.body['beta_first_name_' + i] || phone;
     }
   }
 
@@ -179,7 +180,7 @@ SGCompetitiveStoryController.prototype.createGame = function(request, response) 
     self.createdGameDoc.betas.forEach(function(value, index, set) {
       var betaData = {
         phone: value.phone,
-        name: value.name,
+        name: (value.name || value.phone),
         docId: self.createdGameDoc._id
       };
       createPlayer(betaData, 'beta-user-created');
@@ -192,6 +193,7 @@ SGCompetitiveStoryController.prototype.createGame = function(request, response) 
 
     // We opt users into these initial opt in paths only if the game type is NOT solo. 
     if (self.createdGameDoc.game_type !== 'solo') {
+      name.addPlayerNamesToAlpha(self.createdGameDoc);
       message.group(self.createdGameDoc.alpha_phone,
         gameConfig.alpha_wait_oip,
         betaOptInArray,

--- a/app/lib/sms-games/controllers/logicBetaJoin.js
+++ b/app/lib/sms-games/controllers/logicBetaJoin.js
@@ -5,6 +5,7 @@ var emitter = rootRequire('app/eventEmitter')
   , message = require('./gameMessageHelpers')
   , SGSoloController = require('./SGSoloController')
   , start = require('./logicGameStart')
+  , name = require('./playerNameHelpers')
   // After player attempts to join a started game, delay before she's opted into a solo game. 
   , BETA_TO_SOLO_AFTER_GAME_ALREADY_STARTED_DELAY = 3000
   ;
@@ -56,7 +57,7 @@ module.exports = function(request, doc) {
   // If we're still waiting on people, send appropriate messages to the recently
   // joined beta and alpha users.
   else {
-    doc = message.wait(gameConfig, doc, joiningBetaPhone);
+    doc = name.betaJoin(gameConfig, doc, joiningBetaPhone);
   }
 
   // Save the doc in the database with the betas and current status updates.

--- a/app/lib/sms-games/controllers/playerNameHelpers.js
+++ b/app/lib/sms-games/controllers/playerNameHelpers.js
@@ -1,21 +1,24 @@
 /**
- * A series of helper functions which help to determine 
+ * A series of helper functions which update Mobile Commons profiles with the names of users 
+ * who are invited to or have joined a game, then sends messages based on those names. 
  */
 var mobilecommons = rootRequire('mobilecommons')
   , emitter = rootRequire('app/eventEmitter')
+  , message = require('./gameMessageHelpers')
+  , record = require('./gameRecordHelpers')
   ;
 
 module.exports = {
-  addPlayerNamesToAlpha : addPlayerNamesToAlpha,
+  alphaInvite : createGameInviteAll,
   betaJoin : betaJoinNotifyAllPlayers
 }
 
 /**
  * Called when an Alpha user creates a game. Updates the Alpha player's 
- * Mobile Commons profile with the names of friends 
- * she's invited, then sends her a message. For the purposes of SMS games, 
- * that message will contain those names. If names aren't present, phone 
- * numbers are used. 
+ * Mobile Commons profile with the names of friends she's invited, then 
+ * sends her the 'game has been created' message and invites all other players. 
+ * For the purposes of SMS games, that message will contain those names. 
+ * If names aren't present, phone numbers are used. 
  *
  * @param  gameDoc
  *  The document storing game data, including player names and numbers. 
@@ -24,22 +27,23 @@ module.exports = {
  *  created a game. Contains the names of invited players. 
  * 
  */
-function addPlayerNamesToAlpha(gameDoc) {
+function createGameInviteAll(gameConfig, gameDoc) {
   var i
     , args
     , profileUpdateString = ''
     , betas = gameDoc.betas
-    ; 
+    ;
 
   for (i = 0; i < betas.length; i++) {
-    profileUpdateString += betas[i].name 
+    profileUpdateString += betas[i].name;
     if (i != betas.length - 1) {
-      profileUpdateString += ', '
+      profileUpdateString += ', ';
     }
+    message.singleUser(betas[i].phone, gameConfig.beta_join_ask_oip);
   }
 
-  args = { 'other_players_not_in_game': profileUpdateString };
-  mobilecommons.profile_update(gameDoc.alpha_phone, null, args);
+  args = { 'players_not_in_game': profileUpdateString };
+  mobilecommons.profile_update(gameDoc.alpha_phone, gameConfig.alpha_wait_oip, args);
   emitter.emit('single-user-opted-in', args);
 }
 
@@ -48,6 +52,7 @@ function addPlayerNamesToAlpha(gameDoc) {
  * 1 - Updates all players' Mobile Commons profile with the names of a) other
  * players who've joined, and b) other players who haven't joined yet. 
  * 2 - Then, sends all players messages containing this info.
+ * 3 - Finally, updates all the gameDoc
  *
  * @param gameConfig
  *  The configuration file for the SMS game. 
@@ -58,5 +63,49 @@ function addPlayerNamesToAlpha(gameDoc) {
  * 
  */
 function betaJoinNotifyAllPlayers(gameConfig, gameDoc, joiningBetaPhone) {
+  var i
+    , j
+    , args
+    , removeIndex
+    , hasJoined = []
+    , hasNotJoined = ''
+    , justJoined = ''
+    , betas = gameDoc.betas
+    ;
 
+  for (i = 0; i < betas.length; i++) {
+    if (!betas[i].invite_accepted) {
+      hasNotJoined = hasNotJoined + betas[i].name + ', ';
+    }
+    else if (betas[i].phone == joiningBetaPhone) {
+      justJoined = betas[i].name;
+    }
+    else {
+      hasJoined.push(betas[i].phone);
+    }
+  }
+
+  removeIndex = hasNotJoined.lastIndexOf(", ");
+  hasNotJoined = hasNotJoined.substring(0, removeIndex);
+
+  args = {
+    'players_not_in_game': hasNotJoined,
+    'player_just_joined': justJoined
+  }
+  
+  // message player who has just joined
+  mobilecommons.profile_update(joiningBetaPhone, gameConfig.beta_wait_oip, args);
+  gameDoc = record.updatedPlayerStatus(gameDoc, joiningBetaPhone, gameConfig.beta_wait_oip);
+
+  // message alpha about who just joined
+  mobilecommons.profile_update(gameDoc.alpha_phone, gameConfig.alpha_start_ask_oip, args);
+  gameDoc = record.updatedPlayerStatus(gameDoc, gameDoc.alpha_phone, gameConfig.alpha_start_ask_oip);
+
+  // message players who have already joined
+  for (j = 0; j < hasJoined.length; j++) {
+    mobilecommons.profile_update(hasJoined[j], gameConfig.notify_joined_betas_that_beta_has_joined, args);
+    gameDoc = record.updatedPlayerStatus(gameDoc, hasJoined[j], gameConfig.notify_joined_betas_that_beta_has_joined);
+  }
+
+  return gameDoc;
 }

--- a/app/lib/sms-games/controllers/playerNameHelpers.js
+++ b/app/lib/sms-games/controllers/playerNameHelpers.js
@@ -1,0 +1,62 @@
+/**
+ * A series of helper functions which help to determine 
+ */
+var mobilecommons = rootRequire('mobilecommons')
+  , emitter = rootRequire('app/eventEmitter')
+  ;
+
+module.exports = {
+  addPlayerNamesToAlpha : addPlayerNamesToAlpha,
+  betaJoin : betaJoinNotifyAllPlayers
+}
+
+/**
+ * Called when an Alpha user creates a game. Updates the Alpha player's 
+ * Mobile Commons profile with the names of friends 
+ * she's invited, then sends her a message. For the purposes of SMS games, 
+ * that message will contain those names. If names aren't present, phone 
+ * numbers are used. 
+ *
+ * @param  gameDoc
+ *  The document storing game data, including player names and numbers. 
+ * @param alphaWaitOip
+ *  The opt in path of the message sent to the alpha alerting her that she's
+ *  created a game. Contains the names of invited players. 
+ * 
+ */
+function addPlayerNamesToAlpha(gameDoc) {
+  var i
+    , args
+    , profileUpdateString = ''
+    , betas = gameDoc.betas
+    ; 
+
+  for (i = 0; i < betas.length; i++) {
+    profileUpdateString += betas[i].name 
+    if (i != betas.length - 1) {
+      profileUpdateString += ', '
+    }
+  }
+
+  args = { 'other_players_not_in_game': profileUpdateString };
+  mobilecommons.profile_update(gameDoc.alpha_phone, null, args);
+  emitter.emit('single-user-opted-in', args);
+}
+
+/**
+ * Called when a Beta user joins a game. 
+ * 1 - Updates all players' Mobile Commons profile with the names of a) other
+ * players who've joined, and b) other players who haven't joined yet. 
+ * 2 - Then, sends all players messages containing this info.
+ *
+ * @param gameConfig
+ *  The configuration file for the SMS game. 
+ * @param gameDoc
+ *  The document storing game data, including player names and number. 
+ * @param joiningBetaPhone
+ *  The phone number of the Beta user who just joined the game. 
+ * 
+ */
+function betaJoinNotifyAllPlayers(gameConfig, gameDoc, joiningBetaPhone) {
+
+}


### PR DESCRIPTION
#### What's this PR do?
1. During the game creation process, sends the alpha messages which let her know the names of players she's invited to the game. 
2. When a beta joins, a) sends that beta a message letting her know which players haven't joined yet, b) sends the alpha a message letting her know the name of the beta that's joined, who they're still waiting on, and whether she wants to begin the game, and c) sends a message to already-joined betas telling them who's joined, and who they're still waiting on. 

It does this by: 
During any state change (an alpha creating a game, a beta joining a game), it updates the necessary Mobile Commons user profiles with user name information and then sends the right messages. 

#### Where should the reviewer start?
The meat is in `playerNameHelpers.js`, within `createGameInviteAll` and `betaJoinNotifyAllPlayers`. There have been minor changes to `SGCompetitiveStoryController.js` to make sure that even if a beta isn't given a first name when a game is created, her first name is stored as her phone number. 

#### How should this be manually tested?
Use [this Postman collection](https://www.getpostman.com/collections/4331949cf475d70cf3db
) to test, perhaps with phone numbers you have access to. Create a game, ensure that the alpha gets a message with the names of the users she's invited, and when betas join, ensure that the proper betas get the right messages. 

I've modified the `Science Sleuth A/B testing` game so that it supports this new feature. This postman collection creates a new game within that campaign. 

**todo:** writing automated tests for this feature. 

#### Any background context you want to provide?
Note that there are a few necessary things for this feature to work:
1. We need to add a `notify_joined_betas_that_beta_has_joined` OIP to the SMS game template. I'm also going to add that property to Intertwine.  
2. We also need to make sure that the `alpha_start_ask_oip` and `beta_wait` messages have the proper liquid templating to display the text strings. 

#### What are the relevant tickets?
Closes #326. 

#### Questions:
1. `notify_joined_betas_that_beta_has_joined` is unwieldy--any suggestions for renaming? 
2. Right now, the names of players are listed in a string as `Tong, Michelle, Vikram`. Should I add an `&` in there somewhere? 
3. I haven't included any obscenity filters or character limitations on the name strings uploaded to Mobile Commons. Should I do so? 