### PR TITLE
Fix for exception during create-game-from-mobile process

### DIFF
--- a/app/lib/sms-games/controllers/SGCreateFromMobileController.js
+++ b/app/lib/sms-games/controllers/SGCreateFromMobileController.js
@@ -46,20 +46,17 @@ SGCreateFromMobileController.prototype.processRequest = function(request, respon
   } 
 
   // @todo When collaborative and most-likely-to games happen, set configs here.
-  // Verify game type and id are valid.
-  if (request.query.story_type == 'competitive-story') {
-    var gameConfigNameString = 'competitive_stories';
-  }
-  else {
+  // Verify game type and id are valid. By default, set to competitive-story.
+  var gameConfigNameString = app.ConfigName.COMPETITIVE_STORIES;
+  if (request.query.story_type != 'competitive-story') {
     response.status(406).send('Invalid story_type.')
     return false;
   }
 
-    self = this
-  , request = request
-  , response = response
-  , gameConfig = app.getConfig(gameConfigNameString, request.query.story_id)
-  ;
+  self = this;
+  request = request;
+  response = response;
+  gameConfig = app.getConfig(gameConfigNameString, request.query.story_id);
 
   if (typeof gameConfig === 'undefined') {
     response.status(406).send('Game config not set up for story ID: ' + request.query.story_id);


### PR DESCRIPTION
Fixes the exception that got triggered during a "create game from mobile" process. Basically the config couldn't be found. The name used to find the config for competitive stories changed from "competitive_stories" to "competitive_story." This fixes that.

Plus some minor code formatting.