### PR TITLE
add autostart for all games

### DIFF
--- a/app/lib/sms-games/controllers/SGCompetitiveStoryController.js
+++ b/app/lib/sms-games/controllers/SGCompetitiveStoryController.js
@@ -126,7 +126,7 @@ SGCompetitiveStoryController.prototype.createGame = function(request, response) 
     emitter.emit('game-created', doc);
 
     // doc.story_id check added in order to A/B test auto-start functionality. 
-    if (doc.game_type != "solo" && doc.story_id == 201) {
+    if (doc.game_type != "solo") {
       // Automatically starts game after specified delay, or opts alpha into solo play.
       start.auto(doc._id);
     }


### PR DESCRIPTION
###What does this PR do?
Previously, we'd added autostart functionality **only** to games created with the id of 201, or to the A/B testing version of Science Sleuth. Now, we remove that flag to allow all created games to use the auto-start functionality. 