### PR TITLE
Update Mobile Commons API integration to facilitate staff pick functionality across affiliate accounts

### DIFF
--- a/app/lib/ds-routing/controllers/MCRouting.js
+++ b/app/lib/ds-routing/controllers/MCRouting.js
@@ -53,7 +53,7 @@ MCRouting.prototype.yesNoGateway = function(request, response) {
 };
 
 /**
- * Transition users for the sign up campaign to the actual campaign.
+ * Transition users from the sign up campaign to the actual campaign.
  */
 MCRouting.prototype.campaignTransition = function(request, response) {
   if (typeof(request.body.mdata_id) === 'undefined') {

--- a/app/lib/reportback/test/reportback.test.js
+++ b/app/lib/reportback/test/reportback.test.js
@@ -311,7 +311,7 @@ function test() {
 
       // Check if correct campaign id opt-out is sent
       emitter.on(emitter.events.mcOptoutTest, function(evtData) {
-        if (evtData.form['person[phone]'] == testData.phone &&
+        if (evtData.form.phone_number == testData.phone &&
             evtData.form.campaign == TEST_CAMPAIGN_CONFIG.campaign_optout_id) {
           onSuccessfulEvent(emitter.events.mcOptoutTest);
         }

--- a/mobilecommons/mobilecommons.js
+++ b/mobilecommons/mobilecommons.js
@@ -187,17 +187,15 @@ exports.optin = function(args) {
  * Opt out of a Mobile Commons campaign.
  */
 exports.optout = function(args) {
-  var url = 'https://secure.mcommons.com/profiles/opt_out';
-
-  var phone = args.phone || null;
-  var campaignId = args.campaignId || null;
-
-  var companyKey = process.env.MOBILECOMMONS_COMPANY_KEY || null;
-  var authEmail = process.env.MOBILECOMMONS_AUTH_EMAIL || null;
-  var authPass = process.env.MOBILECOMMONS_AUTH_PASS || null;
+  var url = 'https://secure.mcommons.com/api/profile_opt_out'
+    , phone = args.phone || null
+    , campaignId = args.campaignId || null
+    , authEmail = process.env.MOBILECOMMONS_AUTH_EMAIL || null
+    , authPass = process.env.MOBILECOMMONS_AUTH_PASS || null
+    ;
 
   // Exit out if one of the values isn't available
-  if (!phone || !campaignId || !companyKey || !authEmail || !authPass) {
+  if (!phone || !campaignId || !authEmail || !authPass) {
     return;
   }
 
@@ -207,9 +205,8 @@ exports.optout = function(args) {
       'pass': authPass
     },
     form: {
-      'person[phone]': phone,
-      campaign: campaignId,
-      company_key: companyKey
+      phone_number: phone,
+      campaign: campaignId
     }
   };
 
@@ -245,4 +242,3 @@ exports.optout = function(args) {
   requestRetry.setRetryConditions([400, 408, 500]);
   requestRetry.post(url, payload, callback);
 };
-

--- a/test/mobilecommons.js
+++ b/test/mobilecommons.js
@@ -126,9 +126,8 @@ describe('mobilecommons.optout', function() {
         pass: 'MOBILECOMMONS_AUTH_PASS'
       },
       form: {
-        'person[phone]': 5555550100,
+        phone_number: 5555550100,
         campaign: 123,
-        company_key: 'MOBILECOMMONS_COMPANY_KEY'
       }
     };
 


### PR DESCRIPTION
#### What's this PR do?
Updates our usage of the Mobile Commons "optout" API so that the API call no longer requires a "company key" param. This facilitates the normal staff pick flow when a user is opted out of the campaign signup flow and opted into the start campaign flow. 

Also updates reportback and mobilecommons tests. 

#### How should this be manually tested?
Tested with the main DoSomething.org affiliate account by testing with personal phone. Texted "WORN" to opt into the Comeback Clothes 2015 signup campaign. Then, opted out of that signup campaign and into the main start campaign flow with [the DS Start Campaign Post in this Postman Collection.](https://www.getpostman.com/collections/468ccfa1dd5e91d672a3) Then checked my phone's profile on MobileCommons to ensure I've successfully been opted out of the signup campaign. 

Still needs to be tested with a campaign on the affiliate account, but none have been set up yet. Will test again when @ArielSD sets it up next week. 

#### What are the relevant tickets?
Closes #413. 