### PR TITLE
fix beta opt in profile update

### DIFF
--- a/app/lib/sms-games/controllers/playerNameHelpers.js
+++ b/app/lib/sms-games/controllers/playerNameHelpers.js
@@ -20,11 +20,10 @@ module.exports = {
  * For the purposes of SMS games, that message will contain those names. 
  * If names aren't present, phone numbers are used. 
  *
+ * @param gameConfig
+ *  The configuration document for the game, containing opt in path ids. 
  * @param  gameDoc
  *  The document storing game data, including player names and numbers. 
- * @param alphaWaitOip
- *  The opt in path of the message sent to the alpha alerting her that she's
- *  created a game. Contains the names of invited players. 
  * 
  */
 function createGameInviteAll(gameConfig, gameDoc) {
@@ -48,14 +47,11 @@ function createGameInviteAll(gameConfig, gameDoc) {
     alphaPhone: gameDoc.alpha_phone,
     alphaOptin: gameConfig.alpha_wait_oip,
     betaPhone: betas,
-    betaOptin: gameConfig.beta_join_ask_oip
+    betaOptin: gameConfig.beta_join_ask_oip,
+    players_not_in_game: profileUpdateString
   };
 
-  function callback(){
-    mobilecommons.optin(args);
-  }
-
-  mobilecommons.profile_update(gameDoc.alpha_phone, null, { 'players_not_in_game': profileUpdateString }, callback);
+  mobilecommons.optin(args);
 }
 
 /**

--- a/app/lib/sms-games/controllers/playerNameHelpers.js
+++ b/app/lib/sms-games/controllers/playerNameHelpers.js
@@ -28,32 +28,20 @@ module.exports = {
  * 
  */
 function createGameInviteAll(gameConfig, gameDoc) {
-  // @todo I'M SORRY TONG. WE'LL FIX THIS LATER.
-  // var i
-  //   , args
-  //   , profileUpdateString = ''
-  //   , betas = gameDoc.betas
-  //   ;
-
-  // for (i = 0; i < betas.length; i++) {
-  //   profileUpdateString += betas[i].name;
-  //   if (i != betas.length - 1) {
-  //     profileUpdateString += ', ';
-  //   }
-  //   message.singleUser(betas[i].phone, gameConfig.beta_join_ask_oip);
-  // }
-
-  // args = { 'players_not_in_game': profileUpdateString };
-  // mobilecommons.profile_update(gameDoc.alpha_phone, gameConfig.alpha_wait_oip, args);
-  // emitter.emit('single-user-opted-in', args);
 
   var args
+    , callback
     , betas = []
+    , profileUpdateString = ''
     , i
     ;
 
   for (i = 0; i < gameDoc.betas.length; i++) {
     betas[i] = gameDoc.betas[i].phone;
+    profileUpdateString += gameDoc.betas[i].name;
+    if (i != gameDoc.betas.length - 1) {
+      profileUpdateString += ', ';
+    }
   }
 
   args = {
@@ -63,7 +51,11 @@ function createGameInviteAll(gameConfig, gameDoc) {
     betaOptin: gameConfig.beta_join_ask_oip
   };
 
-  mobilecommons.optin(args);
+  function callback(){
+    mobilecommons.optin(args);
+  }
+
+  mobilecommons.profile_update(gameDoc.alpha_phone, null, { 'players_not_in_game': profileUpdateString }, callback);
 }
 
 /**

--- a/mobilecommons/mobilecommons.js
+++ b/mobilecommons/mobilecommons.js
@@ -22,9 +22,11 @@ RequestRetry.setDefaults({timeout: 120000});
 *   Opt-in path to subscribe the user to.
 * @param customFields
 *   Array of custom profile field names and values to update the user with.
+* @param externalCallback
+*   A callback to run  when the request returns, if provided. 
 */
 
-exports.profile_update = function(phone, optInPathId, customFields) {
+exports.profile_update = function(phone, optInPathId, customFields, externalCallback) {
   var url = 'https://secure.mcommons.com/api/profile_update';
   var authEmail = process.env.MOBILECOMMONS_AUTH_EMAIL;
   var authPass = process.env.MOBILECOMMONS_AUTH_PASS;
@@ -67,6 +69,12 @@ exports.profile_update = function(phone, optInPathId, customFields) {
         + phone + ' | form data: ' + JSON.stringify(postData.form)
         + '| with code: ' + response.statusCode 
         + ' | body: ' + body + ' | stack: ' + trace);
+    }
+    else {
+      // If an external callback is provided, run it here. 
+      if (externalCallback) {
+        externalCallback();
+      }
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "q": "^1.0.1",
     "request": "2.34.x",
     "stathat": "0.0.8",
+    "underscore": "^1.8.3",
     "winston": "0.8.x",
     "winston-mongodb": "0.5.x"
   },

--- a/test/mobilecommons.js
+++ b/test/mobilecommons.js
@@ -5,6 +5,7 @@
 var assert = require('assert')
   , mobilecommons = rootRequire('mobilecommons')
   , emitter = rootRequire('app/eventEmitter')
+  , _ = require('underscore')
   ;
 
 var setMobileCommonsTestCredentials = function() {
@@ -35,7 +36,7 @@ describe('mobilecommons.optin with just an Alpha', function() {
     emitter.on(emitter.events.mcOptinTest, function(payload) {
       emitter.removeAllListeners(emitter.events.mcOptinTest);
 
-      if (JSON.stringify(payload) == JSON.stringify(expected)) {
+      if (_.isEqual(payload, expected)) {
         done();
       }
       else {
@@ -67,7 +68,7 @@ describe('mobilecommons.optin with an Alpha and 1 Beta', function() {
     emitter.on(emitter.events.mcOptinTest, function(payload) {
       emitter.removeAllListeners(emitter.events.mcOptinTest);
 
-      if (JSON.stringify(payload) == JSON.stringify(expected)) {
+      if (_.isEqual(payload, expected)) {
         done();
       }
       else {
@@ -99,8 +100,7 @@ describe('mobilecommons.optin with Alpha and 2 Betas', function() {
 
     emitter.on(emitter.events.mcOptinTest, function(payload) {
       emitter.removeAllListeners(emitter.events.mcOptinTest);
-
-      if (JSON.stringify(payload) == JSON.stringify(expected)) {
+      if (_.isEqual(payload, expected)) {
         done();
       }
       else {
@@ -135,7 +135,7 @@ describe('mobilecommons.optout', function() {
     emitter.on(emitter.events.mcOptoutTest, function(payload) {
       emitter.removeAllListeners(emitter.events.mcOptoutTest);
 
-      if (JSON.stringify(payload) == JSON.stringify(expected)) {
+      if (_.isEqual(payload, expected)) {
         done();
       }
       else {
@@ -171,7 +171,7 @@ describe('mobilecommons.profile_update', function() {
     emitter.on(emitter.events.mcProfileUpdateTest, function(payload) {
       emitter.removeAllListeners(emitter.events.mcProfileUpdateTest);
 
-      if (JSON.stringify(payload) == JSON.stringify(expected)) {
+      if (_.isEqual(payload, expected)) {
         done();
       }
       else {
@@ -213,7 +213,7 @@ describe('mobilecommons.profile_update with custom fields', function() {
     emitter.on(emitter.events.mcProfileUpdateTest, function(payload) {
       emitter.removeAllListeners(emitter.events.mcProfileUpdateTest);
 
-      if (JSON.stringify(payload) == JSON.stringify(expected)) {
+      if (_.isEqual(payload, expected)) {
         done();
       }
       else {


### PR DESCRIPTION
#### What's this PR do?
Code prior to #416 was breaking beta tell-a-friend functionality. But then #416 took out the code that allowed some messages with player names to work. We're reconciling everything. 

Now, messages with player names work, and beta tell-a-friend functionality still works. 

We've added a callback to the `mobilecommons.profile_update` function to make everything work. 

#### How should this be manually tested?
Use [this Postman collection](https://www.getpostman.com/collections/4331949cf475d70cf3db
) to test, perhaps with phone numbers you have access to. Create a game, ensure that the alpha gets a message with the names of the users she's invited, and when betas join, ensure that the proper betas get the right messages. 

I've modified the `Science Sleuth A/B testing` game so that it supports this new feature. This postman collection creates a new game within that campaign. 

#### What are the relevant tickets?
Closes #420 

#### Questions:
Is adding an optional callback inelegant? Is there a better way of doing it? 
