### PR TITLE
minor changes to facilitate A/B testing player names on onboarding process

### DIFF
--- a/app/lib/sms-games/controllers/playerNameHelpers.js
+++ b/app/lib/sms-games/controllers/playerNameHelpers.js
@@ -110,8 +110,8 @@ function betaJoinNotifyAllPlayers(gameConfig, gameDoc, joiningBetaPhone) {
 
   // message players who have already joined
   for (j = 0; j < hasJoined.length; j++) {
-    mobilecommons.profile_update(hasJoined[j], gameConfig.notify_joined_betas_that_beta_has_joined, args);
-    gameDoc = record.updatedPlayerStatus(gameDoc, hasJoined[j], gameConfig.notify_joined_betas_that_beta_has_joined);
+    mobilecommons.profile_update(hasJoined[j], gameConfig.beta_joined_notify_other_betas_oip, args);
+    gameDoc = record.updatedPlayerStatus(gameDoc, hasJoined[j], gameConfig.beta_joined_notify_other_betas_oip);
   }
 
   return gameDoc;

--- a/mobilecommons/mobilecommons.js
+++ b/mobilecommons/mobilecommons.js
@@ -135,7 +135,6 @@ exports.optin = function(args) {
   // If we're in a test env, just log and emit an event.
   if (process.env.NODE_ENV == 'test') {
     logger.info('mobilecommons.optin: ', args);
-    console.log('payload****: ', payload)
     emitter.emit(emitter.events.mcOptinTest, payload);
     return;
   }


### PR DESCRIPTION
#### What's this PR do?
Minor changes in service of A/B testing player names on onboarding process. 

#### How should this be manually tested?
Doesn't really need to be. Just changed the official name of what the `beta_joined_notify_other_betas_oip` is named in the config file. 