### PR TITLE
add beta_joined_notify_other_betas_oip to mongoose schema

### DIFF
--- a/app/lib/sms-games/config/competitiveStoriesConfigModel.js
+++ b/app/lib/sms-games/config/competitiveStoriesConfigModel.js
@@ -36,6 +36,12 @@ var competitiveStoriesConfigSchema = new mongoose.Schema({
   // A message informing the user about the solo play option. 
   ask_solo_play : Number,
 
+  // A message sent to a betas who have already joined after a beta joins. 
+  beta_joined_notify_other_betas_oip : Number,
+
+  // Object containing data relevant when story is imported into Intertwine. 
+  _twinedata : {},
+ 
   // Collection of messages corresponding to the create-from-mobile user flow.
   mobile_create: {
 


### PR DESCRIPTION
#### What's this PR do?
This PR fixes a bug--previously, we were unable to access the beta_joined_notify_other_betas_oip in playerNameHelpers.js because it wasn't defined within the mongoose model. Everything should work now. 

#### How should this be manually tested?
Creating a game, getting to the beta join point in the game creation process. 