### PR TITLE
adding player names to end-level feedback

### DIFF
--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -39,6 +39,7 @@ var Q = require('q')
   , mobilecommons = rootRequire('mobilecommons')
   , smsHelper = rootRequire('app/lib/smsHelpers')
   , shortenLink = rootRequire('app/lib/bitly')
+  , stringValidator = rootRequire('app/lib/string-validators')
   ;
 
 var connectionOperations = rootRequire('app/config/connectionOperations')
@@ -203,7 +204,7 @@ DonorsChooseDonationController.prototype.retrieveEmail = function(request, respo
   // if it's non-obscene and is actually an email. Otherwise,
   // the submitDonation() function inserts a default DoSomething.org 
   // email address.
-  if (isValidEmail(userSubmittedEmail) && !containsNaughtyWords(userSubmittedEmail)) {
+  if (stringValidator.isValidEmail(userSubmittedEmail) && !stringValidator.containsNaughtyWords(userSubmittedEmail)) {
     updateObject['$set'].email = userSubmittedEmail;
   }
   
@@ -362,7 +363,7 @@ DonorsChooseDonationController.prototype.retrieveFirstName = function(request, r
   var userSubmittedName = smsHelper.getFirstWord(request.body.args);
   var req = request;
 
-  if (containsNaughtyWords(userSubmittedName) || !userSubmittedName) {
+  if (stringValidator.containsNaughtyWords(userSubmittedName) || !userSubmittedName) {
     userSubmittedName = 'Anonymous';
   }
 
@@ -415,7 +416,7 @@ DonorsChooseDonationController.prototype.retrieveLocation = function(request, re
   var location = smsHelper.getFirstWord(request.body.args);
 
   if (TYPE_OF_LOCATION_WE_ARE_QUERYING_FOR == 'zip') {
-    if (!isValidZip(location)) {
+    if (!stringValidator.isValidZip(location)) {
       sendSMS(request.body.phone, config.invalid_zip_oip);
       logger.info('User ' + request.body.phone 
         + ' did not submit a valid zipcode in the DonorsChoose.org flow.');
@@ -423,7 +424,7 @@ DonorsChooseDonationController.prototype.retrieveLocation = function(request, re
     }
   }
   else if (TYPE_OF_LOCATION_WE_ARE_QUERYING_FOR == 'state') {
-    if (!isValidState(location)) {
+    if (!stringValidator.isValidState(location)) {
       sendSMS(request.body.phone, config.invalid_state_oip);
       logger.info('User ' + request.body.phone 
         + ' did not submit a valid state abbreviation in the DonorsChoose.org flow.');
@@ -513,65 +514,5 @@ function onPromiseErrorCallback(err) {
 function sendSMS(phone, oip) {
   mobilecommons.profile_update(phone, oip);
 };
-
-/**
- * Check if string is an abbreviated US state.
- *
- * @param state
- * @return Boolean
- */
-function isValidState(state) {
-  var states = 'AL|AK|AZ|AR|CA|CO|CT|DE|FL|GA|HI|ID|IL|IN|IA|KS|KY|LA|ME|MD|MA|MI|MN|MS|MO|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|VA|WA|WV|WI|WY|GU|PR|VI';
-  var split = states.split('|');
-  if (split.indexOf(state.toUpperCase()) > -1) {
-    return true;
-  }
-  else {
-    return false;
-  }
-}
-
-/**
- * Check if string is a valid zip code.
- *
- * @param zip
- * @return Boolean
- */
-function isValidZip(zip) {
-  return /(^\d{5}$)|(^\d{5}-\d{4}$)/.test(zip);
-}
-
-/**
- * Check if string is a valid email address.
- *
- * @param email
- * @return Boolean
- */
-function isValidEmail(email) { 
-    var re = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-    return re.test(email);
-}
-
-/**
- * Checks to see if user inputted strings contains naughty words. 
- *
- * @param phone
- *  Phone number to subscribe.
- * @param oip
- *   Opt-in path to subscribe to.
- */
-
-function containsNaughtyWords(stringToBeCensored) {
-  var naughtyWords = [ '2g1c', '2girls 1 cup', 'acrotomophilia', 'anal', 'anilingus', 'anus', 'arsehole', 'ass', 'asshole', 'assmunch', 'autoerotic', 'autoerotic', 'babeland', 'babybatter', 'ballgag', 'ballgravy', 'ballkicking', 'balllicking', 'ballsack', 'ballsucking', 'bangbros', 'bareback', 'barelylegal', 'barenaked', 'bastardo', 'bastinado', 'bbw', 'bdsm', 'beavercleaver', 'beaverlips', 'bestiality', 'bicurious', 'bigblack', 'bigbreasts', 'bigknockers', 'bigtits', 'bimbos', 'birdlock', 'bitch', 'blackcock', 'blondeaction', 'blondeon blonde action', 'blowj', 'blowyourl', 'bluewaffle', 'blumpkin', 'bollocks', 'bondage', 'boner', 'boob', 'boobs', 'bootycall', 'brownshowers', 'brunetteaction', 'bukkake', 'bulldyke', 'bulletvibe', 'bunghole', 'bunghole', 'busty', 'butt', 'buttcheeks', 'butthole', 'cameltoe', 'camgirl', 'camslut', 'camwhore', 'carpetmuncher', 'carpetmuncher', 'chink', 'chocolaterosebuds', 'circlejerk', 'clevelandsteamer', 'clit', 'clitoris', 'cloverclamps', 'clusterfuck', 'cock', 'cocks', 'coprolagnia', 'coprophilia', 'cornhole', 'cum', 'cumming', 'cunnilingus', 'cunt', 'darkie', 'daterape', 'daterape', 'deepthroat', 'deepthroat', 'dick', 'dildo', 'dirtypillows', 'dirtysanchez', 'doggiestyle', 'doggiestyle', 'doggystyle', 'doggystyle', 'dogstyle', 'dolcett', 'domination', 'dominatrix', 'dommes', 'donkeypunch', 'doubledong', 'doublepenetration', 'dpaction', 'eatmyass', 'ecchi', 'ejaculation', 'erotic', 'erotism', 'escort', 'ethicalslut', 'eunuch', 'faggot', 'fecal', 'felch', 'fellatio', 'feltch', 'femalesquirting', 'femdom', 'figging', 'fingering', 'fisting', 'footfetish', 'footjob', 'frotting', 'fuck', 'fuckbuttons', 'fudgepacker', 'fudgepacker', 'futanari', 'gangbang', 'gaysex', 'genitals', 'giantcock', 'girlon', 'girlontop', 'girlsgonewild', 'goatcx', 'goatse', 'gokkun', 'goldenshower', 'goodpoop', 'googirl', 'goregasm', 'grope', 'groupsex', 'g-spot', 'guro', 'handjob', 'handjob', 'hardcore', 'hardcore', 'hentai', 'homoerotic', 'honkey', 'hooker', 'hotchick', 'howto kill', 'howto murder', 'hugefat', 'humping', 'incest', 'intercourse', 'jackoff', 'jailbait', 'jailbait', 'jerkoff', 'jigaboo', 'jiggaboo', 'jiggerboo', 'jizz', 'juggs', 'kike', 'kinbaku', 'kinkster', 'kinky', 'knobbing', 'leatherrestraint', 'leatherstraight jacket', 'lemonparty', 'lolita', 'lovemaking', 'makeme come', 'malesquirting', 'masturbate', 'menagea trois', 'milf', 'missionaryposition', 'motherfucker', 'moundofvenus', 'mrhands', 'muffdiver', 'muffdiving', 'nambla', 'nawashi', 'negro', 'neonazi', 'nigga', 'nigger', 'nignog', 'nimphomania', 'nipple', 'nipples', 'nsfwimages', 'nude', 'nudity', 'nympho', 'nymphomania', 'octopussy', 'omorashi', 'onecuptwogirls', 'oneguyone jar', 'orgasm', 'orgy', 'paedophile', 'panties', 'panty', 'pedobear', 'pedophile', 'pegging', 'penis', 'phonesex', 'pieceofshit', 'pissing', 'pisspig', 'pisspig', 'playboy', 'pleasurechest', 'polesmoker', 'ponyplay', 'poof', 'poopchute', 'poopchute', 'porn', 'porno', 'pornography', 'princealbert piercing', 'pthc', 'pubes', 'pussy', 'queaf', 'raghead', 'ragingboner', 'rape', 'raping', 'rapist', 'rectum', 'reversecowgirl', 'rimjob', 'rimming', 'rosypalm', 'rosypalm and her 5 sisters', 'rustytrombone', 'sadism', 'scat', 'schlong', 'scissoring', 'semen', 'sex', 'sexo', 'sexy', 'shavedbeaver', 'shavedpussy', 'shemale', 'shibari', 'shit', 'shota', 'shrimping', 'slanteye', 'slut', 's&m', 'smut', 'snatch', 'snowballing', 'sodomize', 'sodomy', 'spic', 'spooge', 'spreadlegs', 'strapon', 'strapon', 'strappado', 'stripclub', 'styledoggy', 'suck', 'sucks', 'suicidegirls', 'sultrywomen', 'swastika', 'swinger', 'taintedlove', 'tastemy', 'teabagging', 'threesome', 'throating', 'tiedup', 'tightwhite', 'tit', 'tits', 'titties', 'titty', 'tongueina', 'topless', 'tosser', 'towelhead', 'tranny', 'tribadism', 'tubgirl', 'tubgirl', 'tushy', 'twat', 'twink', 'twinkie', 'twogirls one cup', 'undressing', 'upskirt', 'urethraplay', 'urophilia', 'vagina', 'venusmound', 'vibrator', 'violetblue', 'violetwand', 'vorarephilia', 'voyeur', 'vulva', 'wank', 'wetback', 'wetdream', 'whitepower', 'womenrapping', 'wrappingmen', 'wrinkledstarfish', 'xx', 'xxx', 'yaoi', 'yellowshowers', 'yiffy', 'zoophilia' ]
-
-  var noSpaceString = stringToBeCensored.toLowerCase().replace(/[^\w\s]/gi, '').replace(' ', '')
-
-  for (var i = 0; i < naughtyWords.length; i++) {
-    if (noSpaceString.indexOf(naughtyWords[i]) != -1) {
-      return true;
-    }
-  } 
-  return false; 
-}
 
 module.exports = DonorsChooseDonationController;

--- a/app/lib/sms-games/config/competitiveStoriesConfigModel.js
+++ b/app/lib/sms-games/config/competitiveStoriesConfigModel.js
@@ -39,6 +39,18 @@ var competitiveStoriesConfigSchema = new mongoose.Schema({
   // A message sent to a betas who have already joined after a beta joins. 
   beta_joined_notify_other_betas_oip : Number,
 
+  // Sent at the end of a level if no players make the correct choice.(failure)
+  end_level_0_correct_loss: Number,
+
+  // Sent at the end of a level if 1/3 or 1/4 players make the correct choice. (failure) 
+  end_level_1_correct_loss: Number,
+
+  // Sent at the end of a level if 1/2, 3/4, or 4/4 players make the correct choice. (success)
+  end_level_1_to_4_correct_win: Number,
+
+  // Sent at the end of a level if 1/1 players make the correct choice. (success)
+  end_level_solo_correct_win: Number,
+
   // Object containing data relevant when story is imported into Intertwine. 
   _twinedata : {},
  

--- a/app/lib/sms-games/controllers/SGCompetitiveStoryController.js
+++ b/app/lib/sms-games/controllers/SGCompetitiveStoryController.js
@@ -30,6 +30,8 @@ var MAX_PLAYERS_TO_INVITE = 3
   , STATHAT_CATEGORY = 'sms-games'
 // Character limit for player names.
   , NAME_CHAR_LIMIT = 10
+// If the user inputs a naughty name to the game, we use this name instead. 
+  , NAUGHTY_NAME = 'IamNaughty'
   ;
 
 var SGCompetitiveStoryController = function() {};
@@ -92,7 +94,7 @@ SGCompetitiveStoryController.prototype.createGame = function(request, response) 
 
   function truncName(name) {
     if (!name) { return null; }
-    else if (stringValidator.containsNaughtyWords(name)) { return "IamNaughty"; }
+    else if (stringValidator.containsNaughtyWords(name)) { return NAUGHTY_NAME; }
     else { return name.substring(0, NAME_CHAR_LIMIT).trim(); }
   }
 

--- a/app/lib/sms-games/controllers/SGCompetitiveStoryController.js
+++ b/app/lib/sms-games/controllers/SGCompetitiveStoryController.js
@@ -17,6 +17,7 @@ var smsHelper = rootRequire('app/lib/smsHelpers')
   , alphaStartLogic = require('./logicAlphaStart')
   , start = require('./logicGameStart')
   , name = require('./playerNameHelpers')
+  , stringValidator = rootRequire('app/lib/string-validators')
   ;
 
 // Maximum number of players that can be invited into a game.
@@ -27,6 +28,8 @@ var MAX_PLAYERS_TO_INVITE = 3
   , TIME_UNTIL_SOLO_MESSAGE_SENT = 300000 // Five minutes is 300000.
 // StatHat analytics marker. 
   , STATHAT_CATEGORY = 'sms-games'
+// Character limit for player names.
+  , NAME_CHAR_LIMIT = 10
   ;
 
 var SGCompetitiveStoryController = function() {};
@@ -46,7 +49,8 @@ SGCompetitiveStoryController.prototype.createGame = function(request, response) 
       gameDoc,
       phone,
       idx,
-      i;
+      i,
+      shortName;
 
   // Return a 406 if some data is missing.
   if (typeof request.body === 'undefined'
@@ -86,10 +90,17 @@ SGCompetitiveStoryController.prototype.createGame = function(request, response) 
     return false;
   }
 
-  // Compile a new game document.
+  function truncName(name) {
+    if (!name) { return null; }
+    else if (stringValidator.containsNaughtyWords(name)) { return "IamNaughty"; }
+    else { return name.substring(0, NAME_CHAR_LIMIT).trim(); }
+  }
+
+  // Compile a new game document. 
+  shortName = truncName(request.body.alpha_first_name);
   gameDoc = {
     story_id: storyId,
-    alpha_name: request.body.alpha_first_name,
+    alpha_name: shortName,
     alpha_phone: alphaPhone,
     betas: [],
     game_type: (request.body.game_type || '')
@@ -97,13 +108,14 @@ SGCompetitiveStoryController.prototype.createGame = function(request, response) 
 
   for (i = 0; i < MAX_PLAYERS_TO_INVITE; i++) {
     phone = request.body['beta_mobile_' + i] ? smsHelper.getNormalizedPhone(request.body['beta_mobile_' + i]) : null;
+    shortName = truncName(request.body['beta_first_name_' + i]);
 
     if (smsHelper.isValidPhone(phone)) {
       idx = gameDoc.betas.length;
       gameDoc.betas[idx] = {};
       gameDoc.betas[idx].invite_accepted = false;
       gameDoc.betas[idx].phone = phone;
-      gameDoc.betas[idx].name = request.body['beta_first_name_' + i] || phone;
+      gameDoc.betas[idx].name = shortName || phone;
     }
   }
 

--- a/app/lib/sms-games/controllers/gameMessageHelpers.js
+++ b/app/lib/sms-games/controllers/gameMessageHelpers.js
@@ -117,7 +117,7 @@ function singleUserWithDelay(phoneNumber, optinPath, delay, currentGameId, userM
         // from her user document. Checking to see if current_game_id still exists for that user. 
         if (userDoc.current_game_id && (userDoc.current_game_id.equals(_currentGameId))) {
           var args = {alphaPhone: _phoneNumber, alphaOptin: _optinPath};
-          if (profileUpdateObj) {
+          if (_profileUpdateObj) {
             for (key in _profileUpdateObj) {
               args[key] = _profileUpdateObj[key];
             }

--- a/app/lib/sms-games/controllers/logicUserAction.js
+++ b/app/lib/sms-games/controllers/logicUserAction.js
@@ -161,17 +161,17 @@ function sendEndMessagesUpdateReturnGameDoc(level, gameDoc) {
    * level message first.
    */
 
-  var gameConfig = app.getConfig(app.ConfigName.COMPETITIVE_STORIES, gameDoc.story_id)
+  var gameConfig = app.getConfig(app.ConfigName.COMPETITIVE_STORIES, gameDoc.story_id);
 
   // Calculate and send player-name specific feedback.
-  playerName.endLevel(gameConfig, gameDoc, END_LEVEL_PLAYER_NAME_MESSAGE_DELAY);
+  gameDoc = playerName.endLevel(gameConfig, gameDoc, END_LEVEL_PLAYER_NAME_MESSAGE_DELAY);
 
   // Send group the end level message.
   var endLevelGroupKey = level + '-GROUP';
   var gameConfig = app.getConfig(app.ConfigName.COMPETITIVE_STORIES, gameDoc.story_id)
   var groupOptin = message.end.level.group(endLevelGroupKey, gameConfig, gameDoc);
   for (var i = 0; i < gameDoc.players_current_status.length; i++) {
-    var playerPhone = gameDoc.players_current_status[i].phone;  
+    var playerPhone = gameDoc.players_current_status[i].phone;
 
     // Send group the end level message. The end level group message is sent 
     // SECOND of all the messages in the logicUserAction() function call.

--- a/app/lib/sms-games/controllers/logicUserAction.js
+++ b/app/lib/sms-games/controllers/logicUserAction.js
@@ -164,7 +164,7 @@ function sendEndMessagesUpdateReturnGameDoc(level, gameDoc) {
   var gameConfig = app.getConfig(app.ConfigName.COMPETITIVE_STORIES, gameDoc.story_id);
 
   // Calculate and send player-name specific feedback.
-  gameDoc = playerName.endLevel(gameConfig, gameDoc, END_LEVEL_PLAYER_NAME_MESSAGE_DELAY);
+  playerName.endLevel(gameConfig, gameDoc, END_LEVEL_PLAYER_NAME_MESSAGE_DELAY);
 
   // Send group the end level message.
   var endLevelGroupKey = level + '-GROUP';

--- a/app/lib/sms-games/controllers/logicUserAction.js
+++ b/app/lib/sms-games/controllers/logicUserAction.js
@@ -92,13 +92,6 @@ module.exports = function(request, doc) {
     if (typeof nextOip === 'string' && nextOip.match(/^END-LEVEL/)) {
       var level = nextOip;
       nextOip = message.end.level.indiv(userPhone, level, gameConfig, gameDoc, 'answer');
-
-// PLAYER INDIV STATUS UPDATED HERE. BUT IS THIS THE END OF THE LEVEL, OR SOMEWHERE ELSE? 
-
-// In other words, can we run the functions we want to run in sendEndMessagesUpdateReturnGameDoc and have the players_current_status section still be valid? YES. 
-
-// SO PLAYER INDIVIDUAL STATUS IS UPDATED HERE. 
-
       gameDoc = record.updatedPlayerStatus(gameDoc, userPhone, nextOip);
       gameDoc = record.updatedStoryResults(gameDoc, userPhone, nextOip);
 
@@ -126,9 +119,6 @@ module.exports = function(request, doc) {
       }
 
       if (allPlayersReadyForNextLevel) {
-
-// At this point, players_current_status will have been updated with individual's most recent choices. Thus, we can check the players_current_status
-
         sendEndMessagesUpdateReturnGameDoc(level, gameDoc);
       }
     }

--- a/app/lib/sms-games/controllers/playerNameHelpers.js
+++ b/app/lib/sms-games/controllers/playerNameHelpers.js
@@ -122,7 +122,7 @@ function betaJoinNotifyAllPlayers(gameConfig, gameDoc, joiningBetaPhone) {
 
 function endLevelMessageWithSuccessPlayerNames(gameConfig, gameDoc, delay) {
   if (!gameConfig.story['END-GAME']['indiv-level-success-oips']) {
-    return gameDoc;
+    return;
   }
 
   var i, j
@@ -137,7 +137,6 @@ function endLevelMessageWithSuccessPlayerNames(gameConfig, gameDoc, delay) {
     , numCorrect
     , numPlayers
     , args
-    , gameDoc = gameDoc
     , currentStatus = gameDoc.players_current_status
     , successPaths = gameConfig.story['END-GAME']['indiv-level-success-oips']
     ;
@@ -199,10 +198,8 @@ function endLevelMessageWithSuccessPlayerNames(gameConfig, gameDoc, delay) {
 
   for (i = 0; i < allPlayers.length; i++) {
     message.singleUserWithDelay(allPlayers[i].phone, endLevelMessage, delay, gameDoc._id, userModel, args);
-    gameDoc = record.updatedStoryResults(gameDoc, allPlayers[i].phone, endLevelMessage);
-    emitter.emit('end-level-player-name-message', args);
+    emitter.emit('end-level-player-name-message', {'players_who_succeeded_at_end_level' : nameString, 'endLevelMessage': endLevelMessage});
   }
-  return gameDoc;
 }
 
 // Removes last comma, add & to penultimate comma

--- a/app/lib/sms-games/controllers/playerNameHelpers.js
+++ b/app/lib/sms-games/controllers/playerNameHelpers.js
@@ -129,8 +129,11 @@ function endLevelMessageWithSuccessPlayerNames(gameConfig, gameDoc, delay) {
     , successConfigKey
     , nameString = ''
     , removeIndex
+    , endLevelMessage
+    , numCorrect
+    , numPlayers
     , currentStatus = gameDoc.players_current_status
-    , successPaths = gameConfig['END-GAME']['indiv-level-success-oips']
+    , successPaths = gameConfig.story['END-GAME']['indiv-level-success-oips']
     ;
 
   // finding all players who gave correct answers
@@ -152,19 +155,43 @@ function endLevelMessageWithSuccessPlayerNames(gameConfig, gameDoc, delay) {
   for (i = 0; i < successPlayers.length; i++) {
     for (j = 0; j < allPlayers.length; j++) {
       if (successPlayers[i].phone == allPlayers[j].phone) {
-        nameString += successPlayers[i].name;
+        nameString += allPlayers[j].name;
         nameString += ', ';
       }
     }
   }
 
-  successConfigKey = successPlayers.length + '/' + allPlayers.length; 
-
-  for (i = 0; i < allPlayers.length; i++) {
-    message.singleUserWithDelay(allPlayers[i].phone, gameConfig['END-LEVEL'][successConfigKey], delay, gameDoc._id, userModel, {'players_level_success' : nameString});
+  numCorrect = successPlayers.length;
+  numPlayers = currentStatus.length;
+  // If no one answered correctly. 
+  if (numCorrect === 0) {
+    endLevelMessage = gameConfig.end_level_0_correct_loss;
+  } 
+  // If one player answered correctly, AND
+  else if (numCorrect === 1) {
+    // There's only one player. 
+    if (numPlayers === 1) {
+      endLevelMessage = gameConfig.end_level_solo_correct_win;
+    }
+    // There are two players. 
+    else if (numPlayers === 2) {
+      endLevelMessage = gameConfig.end_level_1_to_4_correct_win;
+    }
+    // There are 3-4 players. 
+    else {
+      endLevelMessage = gameConfig.end_level_1_correct_loss;
+    }
+  }
+  // If two more players answered correctly.
+  else if (numCorrect > 1) {
+    endLevelMessage = gameConfig.end_level_1_to_4_correct_win;
   }
 
-  removeIndex = hasNotJoined.lastIndexOf(", ");
+  for (i = 0; i < allPlayers.length; i++) {
+    message.singleUserWithDelay(allPlayers[i].phone, endLevelMessage, delay, gameDoc._id, userModel, {'players_who_succeeded_at_end_level' : nameString});
+  }
+
+  removeIndex = nameString.lastIndexOf(", ");
   nameString = nameString.substring(0, removeIndex);
 
 }

--- a/app/lib/sms-games/controllers/playerNameHelpers.js
+++ b/app/lib/sms-games/controllers/playerNameHelpers.js
@@ -187,11 +187,10 @@ function endLevelMessageWithSuccessPlayerNames(gameConfig, gameDoc, delay) {
     endLevelMessage = gameConfig.end_level_1_to_4_correct_win;
   }
 
-  for (i = 0; i < allPlayers.length; i++) {
-    message.singleUserWithDelay(allPlayers[i].phone, endLevelMessage, delay, gameDoc._id, userModel, {'players_who_succeeded_at_end_level' : nameString});
-  }
-
   removeIndex = nameString.lastIndexOf(", ");
   nameString = nameString.substring(0, removeIndex);
 
+  for (i = 0; i < allPlayers.length; i++) {
+    message.singleUserWithDelay(allPlayers[i].phone, endLevelMessage, delay, gameDoc._id, userModel, {'players_who_succeeded_at_end_level' : nameString});
+  }
 }

--- a/app/lib/sms-games/controllers/playerNameHelpers.js
+++ b/app/lib/sms-games/controllers/playerNameHelpers.js
@@ -121,6 +121,10 @@ function betaJoinNotifyAllPlayers(gameConfig, gameDoc, joiningBetaPhone) {
 }
 
 function endLevelMessageWithSuccessPlayerNames(gameConfig, gameDoc, delay) {
+  if (!gameConfig.story['END-GAME']['indiv-level-success-oips']) {
+    return;
+  }
+
   var i, j
     , path
     , alphaPlayer

--- a/app/lib/sms-games/controllers/playerNameHelpers.js
+++ b/app/lib/sms-games/controllers/playerNameHelpers.js
@@ -122,7 +122,7 @@ function betaJoinNotifyAllPlayers(gameConfig, gameDoc, joiningBetaPhone) {
 
 function endLevelMessageWithSuccessPlayerNames(gameConfig, gameDoc, delay) {
   if (!gameConfig.story['END-GAME']['indiv-level-success-oips']) {
-    return;
+    return gameDoc;
   }
 
   var i, j
@@ -137,6 +137,7 @@ function endLevelMessageWithSuccessPlayerNames(gameConfig, gameDoc, delay) {
     , numCorrect
     , numPlayers
     , args
+    , gameDoc = gameDoc
     , currentStatus = gameDoc.players_current_status
     , successPaths = gameConfig.story['END-GAME']['indiv-level-success-oips']
     ;
@@ -198,8 +199,10 @@ function endLevelMessageWithSuccessPlayerNames(gameConfig, gameDoc, delay) {
 
   for (i = 0; i < allPlayers.length; i++) {
     message.singleUserWithDelay(allPlayers[i].phone, endLevelMessage, delay, gameDoc._id, userModel, args);
+    gameDoc = record.updatedStoryResults(gameDoc, allPlayers[i].phone, endLevelMessage);
     emitter.emit('end-level-player-name-message', args);
   }
+  return gameDoc;
 }
 
 // Removes last comma, add & to penultimate comma

--- a/app/lib/sms-games/controllers/playerNameHelpers.js
+++ b/app/lib/sms-games/controllers/playerNameHelpers.js
@@ -91,7 +91,7 @@ function betaJoinNotifyAllPlayers(gameConfig, gameDoc, joiningBetaPhone) {
       justJoined = betas[i].name;
     }
     else {
-      hasJoined.push(betas[i].name);
+      hasJoined.push(betas[i].phone);
     }
   }
 
@@ -136,6 +136,7 @@ function endLevelMessageWithSuccessPlayerNames(gameConfig, gameDoc, delay) {
     , endLevelMessage
     , numCorrect
     , numPlayers
+    , args
     , currentStatus = gameDoc.players_current_status
     , successPaths = gameConfig.story['END-GAME']['indiv-level-success-oips']
     ;
@@ -193,8 +194,11 @@ function endLevelMessageWithSuccessPlayerNames(gameConfig, gameDoc, delay) {
 
   nameString = removeLastCommaAddAnd(nameString);
 
+  args = {'players_who_succeeded_at_end_level' : nameString};
+
   for (i = 0; i < allPlayers.length; i++) {
-    message.singleUserWithDelay(allPlayers[i].phone, endLevelMessage, delay, gameDoc._id, userModel, {'players_who_succeeded_at_end_level' : nameString});
+    message.singleUserWithDelay(allPlayers[i].phone, endLevelMessage, delay, gameDoc._id, userModel, args);
+    emitter.emit('end-level-player-name-message', args);
   }
 }
 

--- a/app/lib/sms-games/controllers/playerNameHelpers.js
+++ b/app/lib/sms-games/controllers/playerNameHelpers.js
@@ -41,11 +41,10 @@ function createGameInviteAll(gameConfig, gameDoc) {
   for (i = 0; i < gameDoc.betas.length; i++) {
     betas[i] = gameDoc.betas[i].phone;
     profileUpdateString += gameDoc.betas[i].name;
-    if (i != gameDoc.betas.length - 1) {
-      profileUpdateString += ', ';
-    }
+    profileUpdateString += ', ';
   }
 
+  console.log('profileUpdateString', profileUpdateString)
   profileUpdateString = removeLastCommaAddAnd(profileUpdateString);
 
   args = {
@@ -88,9 +87,6 @@ function betaJoinNotifyAllPlayers(gameConfig, gameDoc, joiningBetaPhone) {
   for (i = 0; i < betas.length; i++) {
     if (!betas[i].invite_accepted) {
       hasNotJoined = hasNotJoined + betas[i].name + ', ';
-    }
-    else if (betas[i].phone == joiningBetaPhone) {
-      justJoined = betas[i].name;
     }
     else {
       hasJoined.push(betas[i].phone);
@@ -201,6 +197,6 @@ function endLevelMessageWithSuccessPlayerNames(gameConfig, gameDoc, delay) {
 
 // Removes last comma, add & to penultimate comma
 function removeLastCommaAddAnd(nameString) {
-  removeIndex = nameString.lastIndexOf(", ");
+  removeIndex = nameString.lastIndexOf(",");
   return nameString.substring(0, removeIndex).replace(/, (?!.*?, )/, ' & ');
 }

--- a/app/lib/sms-games/controllers/playerNameHelpers.js
+++ b/app/lib/sms-games/controllers/playerNameHelpers.js
@@ -106,18 +106,15 @@ function betaJoinNotifyAllPlayers(gameConfig, gameDoc, joiningBetaPhone) {
   // message player who has just joined
   mobilecommons.profile_update(joiningBetaPhone, gameConfig.beta_wait_oip, args);
   gameDoc = record.updatedPlayerStatus(gameDoc, joiningBetaPhone, gameConfig.beta_wait_oip);
-  emitter.emit('beta-join-notify-self', args);
 
   // message alpha about who just joined
   mobilecommons.profile_update(gameDoc.alpha_phone, gameConfig.alpha_start_ask_oip, args);
   gameDoc = record.updatedPlayerStatus(gameDoc, gameDoc.alpha_phone, gameConfig.alpha_start_ask_oip);
-  emitter.emit('beta-join-notify-alpha', args);
 
   // message players who have already joined
   for (j = 0; j < hasJoined.length; j++) {
     mobilecommons.profile_update(hasJoined[j], gameConfig.beta_joined_notify_other_betas_oip, args);
     gameDoc = record.updatedPlayerStatus(gameDoc, hasJoined[j], gameConfig.beta_joined_notify_other_betas_oip);
-    emitter.emit('beta-join-notify-other-betas', args);
   }
 
   return gameDoc;

--- a/app/lib/sms-games/controllers/playerNameHelpers.js
+++ b/app/lib/sms-games/controllers/playerNameHelpers.js
@@ -46,6 +46,8 @@ function createGameInviteAll(gameConfig, gameDoc) {
     }
   }
 
+  profileUpdateString = removeLastCommaAddAnd(profileUpdateString);
+
   args = {
     alphaPhone: gameDoc.alpha_phone,
     alphaOptin: gameConfig.alpha_wait_oip,
@@ -95,8 +97,7 @@ function betaJoinNotifyAllPlayers(gameConfig, gameDoc, joiningBetaPhone) {
     }
   }
 
-  removeIndex = hasNotJoined.lastIndexOf(", ");
-  hasNotJoined = hasNotJoined.substring(0, removeIndex);
+  hasNotJoined = removeLastCommaAddAnd(hasNotJoined);
 
   args = {
     'players_not_in_game': hasNotJoined,
@@ -191,10 +192,15 @@ function endLevelMessageWithSuccessPlayerNames(gameConfig, gameDoc, delay) {
     endLevelMessage = gameConfig.end_level_1_to_4_correct_win;
   }
 
-  removeIndex = nameString.lastIndexOf(", ");
-  nameString = nameString.substring(0, removeIndex);
+  nameString = removeLastCommaAddAnd(nameString);
 
   for (i = 0; i < allPlayers.length; i++) {
     message.singleUserWithDelay(allPlayers[i].phone, endLevelMessage, delay, gameDoc._id, userModel, {'players_who_succeeded_at_end_level' : nameString});
   }
+}
+
+// Removes last comma, add & to penultimate comma
+function removeLastCommaAddAnd(nameString) {
+  removeIndex = nameString.lastIndexOf(", ");
+  return nameString.substring(0, removeIndex).replace(/, (?!.*?, )/, ' & ');
 }

--- a/app/lib/sms-games/controllers/playerNameHelpers.js
+++ b/app/lib/sms-games/controllers/playerNameHelpers.js
@@ -121,7 +121,9 @@ function betaJoinNotifyAllPlayers(gameConfig, gameDoc, joiningBetaPhone) {
 }
 
 function endLevelMessageWithSuccessPlayerNames(gameConfig, gameDoc, delay) {
-  if (!gameConfig.story['END-GAME']['indiv-level-success-oips']) {
+  // @TODO: once we've moved this feature off the A/B game and into the main 
+  // production game, remove the reference to story_id !== 301. Inelegant, I know. :(
+  if (!gameConfig.story['END-GAME']['indiv-level-success-oips'] || gameDoc.story_id !== 301) {
     return;
   }
 

--- a/app/lib/string-validators/index.js
+++ b/app/lib/string-validators/index.js
@@ -1,0 +1,66 @@
+module.exports = {
+  isValidState : isValidState,
+  isValidZip : isValidZip,
+  isValidEmail : isValidEmail,
+  containsNaughtyWords : containsNaughtyWords
+}
+
+/**
+ * Check if string is an abbreviated US state.
+ *
+ * @param state
+ * @return Boolean
+ */
+function isValidState(state) {
+  var states = 'AL|AK|AZ|AR|CA|CO|CT|DE|FL|GA|HI|ID|IL|IN|IA|KS|KY|LA|ME|MD|MA|MI|MN|MS|MO|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|VA|WA|WV|WI|WY|GU|PR|VI';
+  var split = states.split('|');
+  if (split.indexOf(state.toUpperCase()) > -1) {
+    return true;
+  }
+  else {
+    return false;
+  }
+}
+
+/**
+ * Check if string is a valid zip code.
+ *
+ * @param zip
+ * @return Boolean
+ */
+function isValidZip(zip) {
+  return /(^\d{5}$)|(^\d{5}-\d{4}$)/.test(zip);
+}
+
+/**
+ * Check if string is a valid email address.
+ *
+ * @param email
+ * @return Boolean
+ */
+function isValidEmail(email) { 
+    var re = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    return re.test(email);
+}
+
+/**
+ * Checks to see if user inputted strings contains naughty words. 
+ *
+ * @param phone
+ *  Phone number to subscribe.
+ * @param oip
+ *   Opt-in path to subscribe to.
+ */
+
+function containsNaughtyWords(stringToBeCensored) {
+  var naughtyWords = [ '2g1c', '2girls 1 cup', 'acrotomophilia', 'anal', 'anilingus', 'anus', 'arsehole', 'ass', 'asshole', 'assmunch', 'autoerotic', 'autoerotic', 'babeland', 'babybatter', 'ballgag', 'ballgravy', 'ballkicking', 'balllicking', 'ballsack', 'ballsucking', 'bangbros', 'bareback', 'barelylegal', 'barenaked', 'bastardo', 'bastinado', 'bbw', 'bdsm', 'beavercleaver', 'beaverlips', 'bestiality', 'bicurious', 'bigblack', 'bigbreasts', 'bigknockers', 'bigtits', 'bimbos', 'birdlock', 'bitch', 'blackcock', 'blondeaction', 'blondeon blonde action', 'blowj', 'blowyourl', 'bluewaffle', 'blumpkin', 'bollocks', 'bondage', 'boner', 'boob', 'boobs', 'bootycall', 'brownshowers', 'brunetteaction', 'bukkake', 'bulldyke', 'bulletvibe', 'bunghole', 'bunghole', 'busty', 'butt', 'buttcheeks', 'butthole', 'cameltoe', 'camgirl', 'camslut', 'camwhore', 'carpetmuncher', 'carpetmuncher', 'chink', 'chocolaterosebuds', 'circlejerk', 'clevelandsteamer', 'clit', 'clitoris', 'cloverclamps', 'clusterfuck', 'cock', 'cocks', 'coprolagnia', 'coprophilia', 'cornhole', 'cum', 'cumming', 'cunnilingus', 'cunt', 'darkie', 'daterape', 'daterape', 'deepthroat', 'deepthroat', 'dick', 'dildo', 'dirtypillows', 'dirtysanchez', 'doggiestyle', 'doggiestyle', 'doggystyle', 'doggystyle', 'dogstyle', 'dolcett', 'domination', 'dominatrix', 'dommes', 'donkeypunch', 'doubledong', 'doublepenetration', 'dpaction', 'eatmyass', 'ecchi', 'ejaculation', 'erotic', 'erotism', 'escort', 'ethicalslut', 'eunuch', 'faggot', 'fecal', 'felch', 'fellatio', 'feltch', 'femalesquirting', 'femdom', 'figging', 'fingering', 'fisting', 'footfetish', 'footjob', 'frotting', 'fuck', 'fuckbuttons', 'fudgepacker', 'fudgepacker', 'futanari', 'gangbang', 'gaysex', 'genitals', 'giantcock', 'girlon', 'girlontop', 'girlsgonewild', 'goatcx', 'goatse', 'gokkun', 'goldenshower', 'goodpoop', 'googirl', 'goregasm', 'grope', 'groupsex', 'g-spot', 'guro', 'handjob', 'handjob', 'hardcore', 'hardcore', 'hentai', 'homoerotic', 'honkey', 'hooker', 'hotchick', 'howto kill', 'howto murder', 'hugefat', 'humping', 'incest', 'intercourse', 'jackoff', 'jailbait', 'jailbait', 'jerkoff', 'jigaboo', 'jiggaboo', 'jiggerboo', 'jizz', 'juggs', 'kike', 'kinbaku', 'kinkster', 'kinky', 'knobbing', 'leatherrestraint', 'leatherstraight jacket', 'lemonparty', 'lolita', 'lovemaking', 'makeme come', 'malesquirting', 'masturbate', 'menagea trois', 'milf', 'missionaryposition', 'motherfucker', 'moundofvenus', 'mrhands', 'muffdiver', 'muffdiving', 'nambla', 'nawashi', 'negro', 'neonazi', 'nigga', 'nigger', 'nignog', 'nimphomania', 'nipple', 'nipples', 'nsfwimages', 'nude', 'nudity', 'nympho', 'nymphomania', 'octopussy', 'omorashi', 'onecuptwogirls', 'oneguyone jar', 'orgasm', 'orgy', 'paedophile', 'panties', 'panty', 'pedobear', 'pedophile', 'pegging', 'penis', 'phonesex', 'pieceofshit', 'pissing', 'pisspig', 'pisspig', 'playboy', 'pleasurechest', 'polesmoker', 'ponyplay', 'poof', 'poopchute', 'poopchute', 'porn', 'porno', 'pornography', 'princealbert piercing', 'pthc', 'pubes', 'pussy', 'queaf', 'raghead', 'ragingboner', 'rape', 'raping', 'rapist', 'rectum', 'reversecowgirl', 'rimjob', 'rimming', 'rosypalm', 'rosypalm and her 5 sisters', 'rustytrombone', 'sadism', 'scat', 'schlong', 'scissoring', 'semen', 'sex', 'sexo', 'sexy', 'shavedbeaver', 'shavedpussy', 'shemale', 'shibari', 'shit', 'shota', 'shrimping', 'slanteye', 'slut', 's&m', 'smut', 'snatch', 'snowballing', 'sodomize', 'sodomy', 'spic', 'spooge', 'spreadlegs', 'strapon', 'strapon', 'strappado', 'stripclub', 'styledoggy', 'suck', 'sucks', 'suicidegirls', 'sultrywomen', 'swastika', 'swinger', 'taintedlove', 'tastemy', 'teabagging', 'threesome', 'throating', 'tiedup', 'tightwhite', 'tit', 'tits', 'titties', 'titty', 'tongueina', 'topless', 'tosser', 'towelhead', 'tranny', 'tribadism', 'tubgirl', 'tubgirl', 'tushy', 'twat', 'twink', 'twinkie', 'twogirls one cup', 'undressing', 'upskirt', 'urethraplay', 'urophilia', 'vagina', 'venusmound', 'vibrator', 'violetblue', 'violetwand', 'vorarephilia', 'voyeur', 'vulva', 'wank', 'wetback', 'wetdream', 'whitepower', 'womenrapping', 'wrappingmen', 'wrinkledstarfish', 'xx', 'xxx', 'yaoi', 'yellowshowers', 'yiffy', 'zoophilia' ]
+
+  var noSpaceString = stringToBeCensored.toLowerCase().replace(/[^\w\s]/gi, '').replace(' ', '')
+
+  for (var i = 0; i < naughtyWords.length; i++) {
+    if (noSpaceString.indexOf(naughtyWords[i]) != -1) {
+      return true;
+    }
+  } 
+  return false; 
+}

--- a/test/BullyText2014.js
+++ b/test/BullyText2014.js
@@ -10,7 +10,7 @@ var assert = require('assert')
   , testHelper = require('./testHelperFunctions')
   ;
 
-describe('Bully Text game being played:', function() {
+describe('Bully Text 2014 game being played:', function() {
   var alphaName = 'alpha';
   var alphaPhone = '5555550200';
   var betaName0 = 'friend0';

--- a/test/BullyText2015ABTest.js
+++ b/test/BullyText2015ABTest.js
@@ -1,0 +1,89 @@
+var assert = require('assert')
+  , express = require('express')
+  , emitter = rootRequire('app/eventEmitter')
+  , connectionOperations = rootRequire('app/config/connectionOperations')
+  , gameMappingModel = rootRequire('app/lib/sms-games/models/sgGameMapping')(connectionOperations)
+  , gameModel = rootRequire('app/lib/sms-games/models/sgCompetitiveStory')(connectionOperations)
+  , userModel = rootRequire('app/lib/sms-games/models/sgUser')(connectionOperations)
+  , SGCompetitiveStoryController = rootRequire('app/lib/sms-games/controllers/SGCompetitiveStoryController')
+  , smsHelper = rootRequire('app/lib/smsHelpers')
+  , testHelper = require('./testHelperFunctions')
+  ;
+
+describe('Bully Text 2015 A/B test version being played:', function() {
+  var alphaName = 'Axl';
+  var alphaPhone = '5555558880';
+  var betaName0 = 'Basque';
+  var betaName1 = 'Chen-Ling';
+  var betaName2 = 'Denzivort';
+  var betaPhone0 = '5555558881';
+  var betaPhone1 = '5555558882';
+  var betaPhone2 = '5555558883';
+  var storyId = 301;
+  var gameConfig = app.getConfig(app.ConfigName.COMPETITIVE_STORIES, storyId)
+
+  before('instantiating game controller, dummy response', testHelper.gameAppSetup);
+
+  describe('Creating a BullyText 2015 A/B test version game', function() {
+    var request;
+    before(function() {
+      // Test request object to create the game.
+      request = {
+        body: {
+          story_id: storyId,
+          alpha_first_name: alphaName,
+          alpha_mobile: alphaPhone,
+          beta_mobile_0: betaPhone0,
+          beta_mobile_1: betaPhone1,
+          beta_mobile_2: betaPhone2
+        }
+      };
+    })
+
+    it('should emit all game doc events', function(done) {
+      var eventCount = 0;
+      var expectedEvents = 6;
+
+      var onEventReceived = function() {
+        eventCount++;
+        if (eventCount == expectedEvents) {
+          done();
+
+          emitter.removeAllListeners('alpha-user-created');
+          emitter.removeAllListeners('beta-user-created');
+          emitter.removeAllListeners('game-mapping-created');
+          emitter.removeAllListeners('game-created');
+        }
+      };
+
+      // 1 expected alpha-user-created event
+      emitter.on('alpha-user-created', onEventReceived);
+      // 3 expected beta-user-created events
+      emitter.on('beta-user-created', onEventReceived);
+      // 1 expected game-mapping-created event
+      emitter.on('game-mapping-created', function(doc) {
+        gameMappingId = doc._id;
+        onEventReceived();
+      });
+      // 1 expected game-created event
+      emitter.on('game-created', function(doc) {
+        gameId = doc._id;
+        onEventReceived();
+      });
+
+      // With event listeners setup, can now create the game.
+      assert.equal(true, this.gameController.createGame(request, response));
+    })
+
+    after(function() {
+      // Remove all test documents
+      userModel.remove({phone: smsHelper.getNormalizedPhone(alphaPhone)}, function() {});
+      userModel.remove({phone: smsHelper.getNormalizedPhone(betaPhone0)}, function() {});
+      userModel.remove({phone: smsHelper.getNormalizedPhone(betaPhone1)}, function() {});
+      userModel.remove({phone: smsHelper.getNormalizedPhone(betaPhone2)}, function() {});
+      gameMappingModel.remove({_id: gameMappingId}, function() {});
+      gameModel.remove({_id: gameId}, function() {});
+      this.gameController = null;
+    })
+  })
+})

--- a/test/BullyText2015ABTest.js
+++ b/test/BullyText2015ABTest.js
@@ -35,7 +35,10 @@ describe('Bully Text 2015 A/B test version being played:', function() {
           alpha_mobile: alphaPhone,
           beta_mobile_0: betaPhone0,
           beta_mobile_1: betaPhone1,
-          beta_mobile_2: betaPhone2
+          beta_mobile_2: betaPhone2,
+          beta_first_name_0: betaName0,
+          beta_first_name_1: betaName1,
+          beta_first_name_2: betaName2
         }
       };
     })
@@ -74,6 +77,116 @@ describe('Bully Text 2015 A/B test version being played:', function() {
       // With event listeners setup, can now create the game.
       assert.equal(true, this.gameController.createGame(request, response));
     })
+
+    describe('Beta 0 joining the game', function() {
+      testHelper.betaJoinGameTest(betaPhone0);
+    })
+
+    describe('Beta 1 joining the game', function() {
+      testHelper.betaJoinGameTest(betaPhone1);
+    })
+
+    describe('Beta 2 joining the game', function() {
+      testHelper.betaJoinGameTest(betaPhone2);
+
+      it('should auto-start the game', function(done) {
+        var alphaStarted = beta0Started = beta1Started = beta2Started = false; // Chaining assignment operators. They all are set to false. 
+        var startOip = gameConfig.story_start_oip;
+        gameModel.findOne({_id: gameId}, function(err, doc) {
+          if (!err && doc) {
+            for (var i = 0; i < doc.players_current_status.length; i++) {
+              if (doc.players_current_status[i].opt_in_path == startOip) {
+                var phone = doc.players_current_status[i].phone;
+                var aPhone = smsHelper.getNormalizedPhone(alphaPhone);
+                var b0Phone = smsHelper.getNormalizedPhone(betaPhone0);
+                var b1Phone = smsHelper.getNormalizedPhone(betaPhone1);
+                var b2Phone = smsHelper.getNormalizedPhone(betaPhone2);
+                if (phone == aPhone)
+                  alphaStarted = true;
+                else if (phone == b0Phone)
+                  beta0Started = true;
+                else if (phone == b1Phone)
+                  beta1Started = true;
+                else if (phone == b2Phone)
+                  beta2Started = true;
+              }
+            }
+          }
+
+          assert(alphaStarted && beta0Started && beta1Started && beta2Started);
+          done();
+        })
+      })
+    })
+
+    // Level 1. 
+    describe(alphaName + ' answers B at L10', function() {
+      testHelper.userActionTest().withPhone(alphaPhone)
+        .withUserInput('B')
+        .expectNextLevelName('L1B')
+        .expectNextLevelMessage(178183)
+        .exec();
+    });
+
+    describe(alphaName + ' answers B at L1B', function() {
+      testHelper.userActionTest().withPhone(alphaPhone)
+        .withUserInput('B')
+        .expectNextLevelName('END-LEVEL1').expectNextLevelMessage(178191).exec();
+    });
+
+    describe(betaName0 + ' answers B at L10', function() {
+      testHelper.userActionTest().withPhone(betaPhone0)
+        .withUserInput('B')
+        .expectNextLevelName('L1B')
+        .expectNextLevelMessage(178183)
+        .exec();
+    });
+
+    describe(betaName0 + ' answers B at L1B', function() {
+      testHelper.userActionTest().withPhone(betaPhone0)
+        .withUserInput('B')
+        .expectNextLevelName('END-LEVEL1')
+        .expectNextLevelMessage(178191)
+        .exec();
+    });
+
+    describe(betaName1 + ' answers B at L10', function() {
+      testHelper.userActionTest().withPhone(betaPhone1)
+        .withUserInput('B')
+        .expectNextLevelName('L1B')
+        .expectNextLevelMessage(178183)
+        .exec();
+    });
+
+    describe(betaName1 + ' answers B at L1B', function() {
+      testHelper.userActionTest().withPhone(betaPhone1)
+        .withUserInput('B')
+        .expectNextLevelName('END-LEVEL1')
+        .expectNextLevelMessage(178191)
+        .exec();
+    });
+
+    describe(betaName2 + ' answers B at L10', function() {
+      testHelper.userActionTest().withPhone(betaPhone2)
+        .withUserInput('B')
+        .expectNextLevelName('L1B')
+        .expectNextLevelMessage(178183)
+        .exec();
+    });
+
+    describe(betaName2 + ' answers B at L1B', function() {
+      testHelper.userActionTest().withPhone(betaPhone2)
+        .withUserInput('B')
+        .expectNextLevelName('END-LEVEL1')
+        .expectNextLevelMessage(178191)
+        .expectEndStageName('END-LEVEL1-GROUP')
+        .expectEndStageMessage(178195)
+        .expectNextStageName('L20')
+        .expectNextStageMessage(178197)
+        .expectPlayerNamesAnsweredCorrectlyThisLevel([])
+        .expectEndLevelPlayerNameSuccessMessage(178436)
+        .exec();
+    });
 
     after(function() {
       // Remove all test documents

--- a/test/BullyText2015ABTest.js
+++ b/test/BullyText2015ABTest.js
@@ -131,7 +131,8 @@ describe('Bully Text 2015 A/B test version being played:', function() {
     describe(alphaName + ' answers B at L1B', function() {
       testHelper.userActionTest().withPhone(alphaPhone)
         .withUserInput('B')
-        .expectNextLevelName('END-LEVEL1').expectNextLevelMessage(178191).exec();
+        .expectNextLevelName('END-LEVEL1')
+        .expectNextLevelMessage(178191).exec();
     });
 
     describe(betaName0 + ' answers B at L10', function() {
@@ -185,6 +186,354 @@ describe('Bully Text 2015 A/B test version being played:', function() {
         .expectNextStageMessage(178197)
         .expectPlayerNamesAnsweredCorrectlyThisLevel([])
         .expectEndLevelPlayerNameSuccessMessage(178436)
+        .exec();
+    });
+
+    // Level 2. 
+    describe(alphaName + ' answers A at L20', function() {
+      testHelper.userActionTest().withPhone(alphaPhone)
+        .withUserInput('A')
+        .expectNextLevelName('L2A')
+        .expectNextLevelMessage(178199)
+        .exec();
+    });
+
+    describe(alphaName + ' answers A at L2A', function() {
+      testHelper.userActionTest().withPhone(alphaPhone)
+        .withUserInput('A')
+        .expectNextLevelName('END-LEVEL2')
+        .expectNextLevelMessage(178203).exec();
+    });
+
+    describe(betaName0 + ' answers B at L20', function() {
+      testHelper.userActionTest().withPhone(betaPhone0)
+        .withUserInput('B')
+        .expectNextLevelName('L2B')
+        .expectNextLevelMessage(178201)
+        .exec();
+    });
+
+    describe(betaName0 + ' answers B at L2B', function() {
+      testHelper.userActionTest().withPhone(betaPhone0)
+        .withUserInput('B')
+        .expectNextLevelName('END-LEVEL2')
+        .expectNextLevelMessage(178209)
+        .exec();
+    });
+
+    describe(betaName1 + ' answers B at L20', function() {
+      testHelper.userActionTest().withPhone(betaPhone1)
+        .withUserInput('B')
+        .expectNextLevelName('L2B')
+        .expectNextLevelMessage(178201)
+        .exec();
+    });
+
+    describe(betaName1 + ' answers B at L2B', function() {
+      testHelper.userActionTest().withPhone(betaPhone1)
+        .withUserInput('B')
+        .expectNextLevelName('END-LEVEL2')
+        .expectNextLevelMessage(178209)
+        .exec();
+    });
+
+    describe(betaName2 + ' answers B at L20', function() {
+      testHelper.userActionTest().withPhone(betaPhone2)
+        .withUserInput('B')
+        .expectNextLevelName('L2B')
+        .expectNextLevelMessage(178201)
+        .exec();
+    });
+
+    describe(betaName2 + ' answers B at L2B', function() {
+      testHelper.userActionTest().withPhone(betaPhone2)
+        .withUserInput('B')
+        .expectNextLevelName('END-LEVEL2')
+        .expectNextLevelMessage(178209)
+        .expectEndStageName('END-LEVEL2-GROUP')
+        .expectEndStageMessage(178213)
+        .expectNextStageName('L30')
+        .expectNextStageMessage(178215)
+        .expectPlayerNamesAnsweredCorrectlyThisLevel([alphaName])
+        .expectEndLevelPlayerNameSuccessMessage(178438)
+        .exec();
+    });
+
+    // Level 3. 
+    describe(alphaName + ' answers A at L30', function() {
+      testHelper.userActionTest().withPhone(alphaPhone)
+        .withUserInput('A')
+        .expectNextLevelName('L3A')
+        .expectNextLevelMessage(178217)
+        .exec();
+    });
+
+    describe(alphaName + ' answers A at L3A', function() {
+      testHelper.userActionTest().withPhone(alphaPhone)
+        .withUserInput('A')
+        .expectNextLevelName('END-LEVEL3')
+        .expectNextLevelMessage(178221).exec();
+    });
+
+    describe(betaName0 + ' answers A at L30', function() {
+      testHelper.userActionTest().withPhone(betaPhone0)
+        .withUserInput('A')
+        .expectNextLevelName('L3A')
+        .expectNextLevelMessage(178217)
+        .exec();
+    });
+
+    describe(betaName0 + ' answers A at L3A', function() {
+      testHelper.userActionTest().withPhone(betaPhone0)
+        .withUserInput('A')
+        .expectNextLevelName('END-LEVEL3')
+        .expectNextLevelMessage(178221)
+        .exec();
+    });
+
+    describe(betaName1 + ' answers B at L30', function() {
+      testHelper.userActionTest().withPhone(betaPhone1)
+        .withUserInput('B')
+        .expectNextLevelName('L3B')
+        .expectNextLevelMessage(178219)
+        .exec();
+    });
+
+    describe(betaName1 + ' answers B at L3B', function() {
+      testHelper.userActionTest().withPhone(betaPhone1)
+        .withUserInput('B')
+        .expectNextLevelName('END-LEVEL3')
+        .expectNextLevelMessage(178227)
+        .exec();
+    });
+
+    describe(betaName2 + ' answers B at L30', function() {
+      testHelper.userActionTest().withPhone(betaPhone2)
+        .withUserInput('B')
+        .expectNextLevelName('L3B')
+        .expectNextLevelMessage(178219)
+        .exec();
+    });
+
+    describe(betaName2 + ' answers B at L3B', function() {
+      testHelper.userActionTest().withPhone(betaPhone2)
+        .withUserInput('B')
+        .expectNextLevelName('END-LEVEL3')
+        .expectNextLevelMessage(178227)
+        .expectEndStageName('END-LEVEL3-GROUP')
+        .expectEndStageMessage(178231)
+        .expectNextStageName('L40')
+        .expectNextStageMessage(178233)
+        .expectPlayerNamesAnsweredCorrectlyThisLevel([alphaName, betaName0])
+        .expectEndLevelPlayerNameSuccessMessage(178440)
+        .exec();
+    });
+
+    // Level 4. 
+    describe(alphaName + ' answers A at L40', function() {
+      testHelper.userActionTest().withPhone(alphaPhone)
+        .withUserInput('A')
+        .expectNextLevelName('L4A')
+        .expectNextLevelMessage(178235)
+        .exec();
+    });
+
+    describe(alphaName + ' answers A at L4A', function() {
+      testHelper.userActionTest().withPhone(alphaPhone)
+        .withUserInput('A')
+        .expectNextLevelName('END-LEVEL4')
+        .expectNextLevelMessage(178239).exec();
+    });
+
+    describe(betaName0 + ' answers A at L40', function() {
+      testHelper.userActionTest().withPhone(betaPhone0)
+        .withUserInput('A')
+        .expectNextLevelName('L4A')
+        .expectNextLevelMessage(178235)
+        .exec();
+    });
+
+    describe(betaName0 + ' answers A at L4A', function() {
+      testHelper.userActionTest().withPhone(betaPhone0)
+        .withUserInput('A')
+        .expectNextLevelName('END-LEVEL4')
+        .expectNextLevelMessage(178239)
+        .exec();
+    });
+
+    describe(betaName1 + ' answers A at L40', function() {
+      testHelper.userActionTest().withPhone(betaPhone1)
+        .withUserInput('A')
+        .expectNextLevelName('L4A')
+        .expectNextLevelMessage(178235)
+        .exec();
+    });
+
+    describe(betaName1 + ' answers A at L4A', function() {
+      testHelper.userActionTest().withPhone(betaPhone1)
+        .withUserInput('A')
+        .expectNextLevelName('END-LEVEL4')
+        .expectNextLevelMessage(178239)
+        .exec();
+    });
+
+    describe(betaName2 + ' answers B at L40', function() {
+      testHelper.userActionTest().withPhone(betaPhone2)
+        .withUserInput('B')
+        .expectNextLevelName('L4B')
+        .expectNextLevelMessage(178237)
+        .exec();
+    });
+
+    describe(betaName2 + ' answers B at L4B', function() {
+      testHelper.userActionTest().withPhone(betaPhone2)
+        .withUserInput('B')
+        .expectNextLevelName('END-LEVEL4')
+        .expectNextLevelMessage(178245)
+        .expectEndStageName('END-LEVEL4-GROUP')
+        .expectEndStageMessage(178247)
+        .expectNextStageName('L50')
+        .expectNextStageMessage(178251)
+        .expectPlayerNamesAnsweredCorrectlyThisLevel([alphaName, betaName0, betaName1])
+        .expectEndLevelPlayerNameSuccessMessage(178440)
+        .exec();
+    });
+
+    // Level 5. 
+    describe(alphaName + ' answers B at L50', function() {
+      testHelper.userActionTest().withPhone(alphaPhone)
+        .withUserInput('B')
+        .expectNextLevelName('L5B')
+        .expectNextLevelMessage(178255)
+        .exec();
+    });
+
+    describe(alphaName + ' answers B at L5B', function() {
+      testHelper.userActionTest().withPhone(alphaPhone)
+        .withUserInput('B')
+        .expectNextLevelName('END-LEVEL5')
+        .expectNextLevelMessage(178263).exec();
+    });
+
+    describe(betaName0 + ' answers B at L50', function() {
+      testHelper.userActionTest().withPhone(betaPhone0)
+        .withUserInput('B')
+        .expectNextLevelName('L5B')
+        .expectNextLevelMessage(178255)
+        .exec();
+    });
+
+    describe(betaName0 + ' answers B at L5B', function() {
+      testHelper.userActionTest().withPhone(betaPhone0)
+        .withUserInput('B')
+        .expectNextLevelName('END-LEVEL5')
+        .expectNextLevelMessage(178263)
+        .exec();
+    });
+
+    describe(betaName1 + ' answers B at L50', function() {
+      testHelper.userActionTest().withPhone(betaPhone1)
+        .withUserInput('B')
+        .expectNextLevelName('L5B')
+        .expectNextLevelMessage(178255)
+        .exec();
+    });
+
+    describe(betaName1 + ' answers B at L5B', function() {
+      testHelper.userActionTest().withPhone(betaPhone1)
+        .withUserInput('B')
+        .expectNextLevelName('END-LEVEL5')
+        .expectNextLevelMessage(178263)
+        .exec();
+    });
+
+    describe(betaName2 + ' answers B at L50', function() {
+      testHelper.userActionTest().withPhone(betaPhone2)
+        .withUserInput('B')
+        .expectNextLevelName('L5B')
+        .expectNextLevelMessage(178255)
+        .exec();
+    });
+
+    describe(betaName2 + ' answers B at L5B', function() {
+      testHelper.userActionTest().withPhone(betaPhone2)
+        .withUserInput('B')
+        .expectNextLevelName('END-LEVEL5')
+        .expectNextLevelMessage(178263)
+        .expectEndStageName('END-LEVEL5-GROUP')
+        .expectEndStageMessage(178265)
+        .expectNextStageName('L60')
+        .expectNextStageMessage(178269)
+        .expectPlayerNamesAnsweredCorrectlyThisLevel([alphaName, betaName0, betaName1, betaName2])
+        .expectEndLevelPlayerNameSuccessMessage(178440)
+        .exec();
+    });
+
+    // Level 6. 
+    describe(alphaName + ' answers A at L60', function() {
+      testHelper.userActionTest().withPhone(alphaPhone)
+        .withUserInput('A')
+        .expectNextLevelName('L6A')
+        .expectNextLevelMessage(178271)
+        .exec();
+    });
+
+    describe(alphaName + ' answers A at L6A', function() {
+      testHelper.userActionTest().withPhone(alphaPhone)
+        .withUserInput('A')
+        .expectNextLevelName('END-LEVEL6')
+        .expectNextLevelMessage(178275).exec();
+    });
+
+    describe(betaName0 + ' answers A at L60', function() {
+      testHelper.userActionTest().withPhone(betaPhone0)
+        .withUserInput('A')
+        .expectNextLevelName('L6A')
+        .expectNextLevelMessage(178271)
+        .exec();
+    });
+
+    describe(betaName0 + ' answers A at L6A', function() {
+      testHelper.userActionTest().withPhone(betaPhone0)
+        .withUserInput('A')
+        .expectNextLevelName('END-LEVEL6')
+        .expectNextLevelMessage(178275)
+        .exec();
+    });
+
+    describe(betaName1 + ' answers A at L60', function() {
+      testHelper.userActionTest().withPhone(betaPhone1)
+        .withUserInput('A')
+        .expectNextLevelName('L6A')
+        .expectNextLevelMessage(178271)
+        .exec();
+    });
+
+    describe(betaName1 + ' answers A at L6A', function() {
+      testHelper.userActionTest().withPhone(betaPhone1)
+        .withUserInput('A')
+        .expectNextLevelName('END-LEVEL6')
+        .expectNextLevelMessage(178275)
+        .exec();
+    });
+
+    describe(betaName2 + ' answers A at L60', function() {
+      testHelper.userActionTest().withPhone(betaPhone2)
+        .withUserInput('A')
+        .expectNextLevelName('L6A')
+        .expectNextLevelMessage(178271)
+        .exec();
+    });
+
+    describe(betaName2 + ' answers A at L6A', function() {
+      testHelper.userActionTest().withPhone(betaPhone2)
+        .withUserInput('A')
+        .expectNextLevelName('END-LEVEL6')
+        .expectNextLevelMessage(178275)
+        .expectEndStageName('END-LEVEL6-GROUP')
+        .expectEndStageMessage(178283)
+        .expectPlayerNamesAnsweredCorrectlyThisLevel([alphaName, betaName0, betaName1, betaName2])
+        .expectEndLevelPlayerNameSuccessMessage(178440)
         .exec();
     });
 

--- a/test/GameAlphaStart.js
+++ b/test/GameAlphaStart.js
@@ -204,9 +204,9 @@ describe('Alpha-Starting a Bully Text game with first names:', function() {
   var betaPhone0 = '5555550101';
   var betaPhone1 = '5555550102';
   var betaPhone2 = '5555550103';
-  var betaName0 = 'beta_name_0';
-  var betaName1 = 'beta_name_1';
-  var betaName2 = 'beta_name_2';
+  var betaName0 = 'betaName_0';
+  var betaName1 = 'betaName_1';
+  var betaName2 = 'betaName_2';
   var storyId = 100;
   var gameConfig = app.getConfig(app.ConfigName.COMPETITIVE_STORIES, storyId)
 

--- a/test/GameAlphaStart.js
+++ b/test/GameAlphaStart.js
@@ -7,7 +7,7 @@ var assert = require('assert')
   , userModel = rootRequire('app/lib/sms-games/models/sgUser')(connectionOperations)
   , SGCompetitiveStoryController = rootRequire('app/lib/sms-games/controllers/SGCompetitiveStoryController')
   , smsHelper = rootRequire('app/lib/smsHelpers')
-  , testHelper = require('./testHelperFunctions')
+  , testHelper = require('./testHelperFunctions') 
   ;
 
 describe('Alpha-Starting a Bully Text game:', function() {
@@ -43,7 +43,7 @@ describe('Alpha-Starting a Bully Text game:', function() {
 
     it('should emit all game doc events', function(done) {
       var eventCount = 0;
-      var expectedEvents = 6;
+      var expectedEvents = 7;
 
       var onEventReceived = function() {
         eventCount++;
@@ -72,6 +72,13 @@ describe('Alpha-Starting a Bully Text game:', function() {
         gameId = doc._id;
         onEventReceived();
       });
+
+      // 1 expected mobilecommons-optin-test event with args containing 3 beta names 
+      emitter.on(emitter.events.mcOptinTest, function(args) {
+        if (args.form['person[players_not_in_game]'] && args.form['person[players_not_in_game]'].split(/[&,]+/).length == 3) {
+          onEventReceived();
+        }
+      })
 
       // With event listeners setup, can now create the game.
       assert.equal(true, this.gameController.createGame(request, response));

--- a/test/GameAlphaStart.js
+++ b/test/GameAlphaStart.js
@@ -185,6 +185,7 @@ describe('Alpha-Starting a Bully Text game:', function() {
         eventCount++;
         if (eventCount === expectedEvents) {
           done();
+          emitter.removeAllListeners('game-updated');
           emitter.removeAllListeners('beta-join-notify-alpha');
           emitter.removeAllListeners('beta-join-notify-self');
         }
@@ -270,6 +271,9 @@ describe('Alpha-Starting a Bully Text game:', function() {
           eventCount ++;
           if (eventCount === expectedEvents) {
             done();
+            emitter.removeAllListeners('game-updated');
+            emitter.removeAllListeners('beta-join-notify-alpha');
+            emitter.removeAllListeners('beta-join-notify-self');
             emitter.removeAllListeners('beta-join-notify-other-betas');
           }
       }
@@ -281,7 +285,7 @@ describe('Alpha-Starting a Bully Text game:', function() {
             assert(false);
           }
           else if (args.player_just_joined != betaName2) {
-            assert(false)
+            assert(false);
           } else {
             onEventReceived();
           }

--- a/test/GameAlphaStart.js
+++ b/test/GameAlphaStart.js
@@ -182,32 +182,30 @@ describe('Alpha-Starting a Bully Text game:', function() {
         ;
 
       function onEventReceived() {
-        eventCount++;
-        if (eventCount === expectedEvents) {
-          done();
-          emitter.removeAllListeners('game-updated');
-          emitter.removeAllListeners('beta-join-notify-alpha');
-          emitter.removeAllListeners('beta-join-notify-self');
-        }
-      };
+          eventCount ++;
+          if (eventCount === expectedEvents) {
+            done();
+            emitter.removeAllListeners(emitter.events.mcProfileUpdateTest);
+            emitter.removeAllListeners('game-updated');
+          }
+      }
 
       function checkArgs(args) {
-        if (args.players_not_in_game) {
-          var playerNameArray = args.players_not_in_game.split(/[&,]+/);
-          if (_.contains(playerNameArray, betaName1)) {
-            assert(false);
-          }
-          else if (args.player_just_joined != betaName1) {
-            assert(false)
-          } else {
+        if (args.form.players_not_in_game && args.form.player_just_joined) {
+          var playerNameArray = args.form.players_not_in_game.split(/[&,]+/);
+          if (!_.contains(playerNameArray, betaName1) && args.form.player_just_joined == betaName1) {
             onEventReceived();
+          } else {
+            assert(false);
           }
         }
       }
 
+      emitter.on(emitter.events.mcProfileUpdateTest, function(postData) {
+        checkArgs(postData);
+      })
+
       emitter.on('game-updated', function() { onEventReceived(); });
-      emitter.on('beta-join-notify-alpha', function(args){ checkArgs(args); });    
-      emitter.on('beta-join-notify-self', function(args){ checkArgs(args); });
 
       this.gameController.betaJoinGame(request, response);
     })
@@ -271,32 +269,27 @@ describe('Alpha-Starting a Bully Text game:', function() {
           eventCount ++;
           if (eventCount === expectedEvents) {
             done();
+            emitter.removeAllListeners(emitter.events.mcProfileUpdateTest);
             emitter.removeAllListeners('game-updated');
-            emitter.removeAllListeners('beta-join-notify-alpha');
-            emitter.removeAllListeners('beta-join-notify-self');
-            emitter.removeAllListeners('beta-join-notify-other-betas');
           }
       }
 
       function checkArgs(args) {
-        if (args.players_not_in_game) {
-          var playerNameArray = args.players_not_in_game.split(/[&,]+/);
-          if (_.contains(playerNameArray, betaName2)) {
-            assert(false);
-          }
-          else if (args.player_just_joined != betaName2) {
-            assert(false);
-          } else {
+        if (args.form.players_not_in_game && args.form.player_just_joined) {
+          var playerNameArray = args.form.players_not_in_game.split(/[&,]+/);
+          if (!_.contains(playerNameArray, betaName2) && args.form.player_just_joined == betaName2) {
             onEventReceived();
+          } else {
+            assert(false);
           }
         }
       }
 
-      emitter.on('game-updated', function() { onEventReceived(); });
-      emitter.on('beta-join-notify-alpha', function(args){ checkArgs(args); });    
-      emitter.on('beta-join-notify-self', function(args){ checkArgs(args); });
-      emitter.on('beta-join-notify-other-betas', function(args){ checkArgs(args); });
+      emitter.on(emitter.events.mcProfileUpdateTest, function(postData) {
+        checkArgs(postData);
+      })
 
+      emitter.on('game-updated', function() { onEventReceived(); });
       this.gameController.betaJoinGame(request, response);
     })
     it('should update the game document that Beta 2 has joined', function(done) {

--- a/test/GameAlphaStart.js
+++ b/test/GameAlphaStart.js
@@ -40,7 +40,7 @@ describe('Alpha-Starting a Bully Text game:', function() {
           beta_mobile_2: betaPhone2, 
           beta_first_name_0: betaName0,
           beta_first_name_1: betaName1,
-          beta_first_name_2: betaName2,
+          beta_first_name_2: betaName2
         }
       };
     });
@@ -182,7 +182,7 @@ describe('Alpha-Starting a Bully Text game:', function() {
         ;
 
       function onEventReceived() {
-          eventCount ++;
+          eventCount++;
           if (eventCount === expectedEvents) {
             done();
             emitter.removeAllListeners(emitter.events.mcProfileUpdateTest);
@@ -266,7 +266,7 @@ describe('Alpha-Starting a Bully Text game:', function() {
         ;
 
       function onEventReceived() {
-          eventCount ++;
+          eventCount++;
           if (eventCount === expectedEvents) {
             done();
             emitter.removeAllListeners(emitter.events.mcProfileUpdateTest);

--- a/test/_init.test.js
+++ b/test/_init.test.js
@@ -19,12 +19,13 @@ describe('Running all responder tests', function() {
   });
 
   it('runs all the responder tests', function() {
-    require('./BullyText.js');
+    require('./BullyText2014.js');
     require('./ds-routing.js');
     require('./EndGameFromUserExit.js');
     require('./GameAlphaStart');
     require('./lib.test.js');
     require('./mobilecommons.js');
     require('./ScienceSleuth.js');
+    require('./BullyText2015ABTest.js');
   })
 });

--- a/test/testHelperFunctions.js
+++ b/test/testHelperFunctions.js
@@ -189,8 +189,8 @@ exports.userActionTest = function() {
         }
       })
 
-      if (this.playerNamesAnsweredCorrectlyThisLevel !== undefined){
-        it('should send messages with the names of players who answered this level correctly as well as the player-status-updated event', function(done) {
+      if (this.playerNamesAnsweredCorrectlyThisLevel !== undefined && this.endLevelPlayerNameSuccessMessage){
+        it('should send the right messages--featuring the names of players who answered this level correctly--as well as fire the player-status-updated event', function(done) {
           // this.playerNamesAnsweredCorrectlyThisLevel should be an array of player names. Like [betaName0, betaName1]
           // we want to count four messages (i.e. all the plyers in the game), and check all their params 
           var eventCount = 0
@@ -209,6 +209,7 @@ exports.userActionTest = function() {
             var expected = self.playerNamesAnsweredCorrectlyThisLevel // An array of expected player names
               , expected2 = self.playerNamesAnsweredCorrectlyThisLevel 
               , actual = args.players_who_succeeded_at_end_level.split(/ *[,&] */) // Splitting this into an array.
+              , expectedMessage = self.endLevelPlayerNameSuccessMessage
               ; 
 
             for (var i = 0; i < actual.length; i++) {
@@ -227,8 +228,8 @@ exports.userActionTest = function() {
               } 
             }
 
-            if (expected.length === 0 && actual.length === 0) {
-              onEventReceived()
+            if (expected.length === 0 && actual.length === 0 && args.endLevelMessage === expectedMessage) {
+              onEventReceived();
             } else {
               assert(false);
             }
@@ -330,44 +331,6 @@ exports.userActionTest = function() {
                 done();
               } 
               else {
-                assert(false);
-              }
-            }
-          })
-        })
-      }
-
-      if (this.playerNamesAnsweredCorrectlyThisLevel && this.endLevelPlayerNameSuccessMessage) {
-        var nameString
-          , self = this
-          ; 
-
-        if (this.playerNamesAnsweredCorrectlyThisLevel.length === 0) {
-          nameString = 'none of the players answered correctly'
-        }
-        else {
-          nameString = this.playerNamesAnsweredCorrectlyThisLevel.join(' ');
-        }
-
-        it('should send send the endlevel message (optin path: ' + this.endLevelPlayerNameSuccessMessage + ') with the names of the players who answered correctly: ' + nameString + ' .', function(done) {
-          var storyResults
-            , playerNum
-            , counter = 0
-            ;
-
-          gameModel.findOne({_id: gameId}, function(err, doc) {
-            if (!err) {
-              storyResults = doc.story_results;
-              playerNum = doc.players_current_status.length;
-
-              storyResults.forEach(function(val, idx, arr) {
-                if (val.oip == self.endLevelPlayerNameSuccessMessage) {
-                  counter ++;
-                }
-              })
-              if (counter === doc.players_current_status.length) {
-                done();
-              } else {
                 assert(false);
               }
             }


### PR DESCRIPTION
#### What's this PR do?
A lot has been changed, but the basic functionality of this PR is simple. It: 
1. Adds a new feature: at the end of each level, all players receive a message telling them which players answered correctly (there's a flag right now to make sure this feature only appears for the story id of 301.)
2. Adds tests for this feature. 
3. Adds a new small module with string helper functions (obscenity checkers, etc.). When players enter their names, our apps now add a character limit (10 chars) and check for obscenities. Player names are also now added to user profiles on mobile commons with a more elegant syntax: "Tom, Barry, & Andrea" instead of "Tom, Barry, Andrea". 

#### Where should the reviewer start?
**Files to pay attention to:**
1. `playerNameHelpers.js` - this is where the `endLevelMessageWithSuccessPlayerNames.js` function is actually written, handling the meat of the end-level player name messaging logic. 
2. `SGcompetitiveStoryController.js`, `gameMessageHelpers.js`, `logicUserAction.js` - have been modified to support the implementation of this feature. 
3. `competitiveStoriesConfigModel.js` - modified to support the four new opt in paths required for the player name feature. 

**Tests files changed
1. `testHelperFunctions.js` now supports checking end-level messages
2. `GameAlphaStart.js` tests the validity of player name messages during the onboarding process. 
3. `BullyText2015ABTest.js` tests the validity of end-level player name messages. 
4. `_init.test.js` starts the new tests. 

**Files to pay less attention to:**
1. `/string-validators/index.js`, `DonorsChooseDonationController.js` - I moved the obscenity checkers out from the DonorsChoose library and into a new library.

#### How should this be manually tested?
`npm test`! I've manually tested this feature extensively with Postman creating a four-user game, but Alysha and @ArielSD will be QB-ing a manual testing strategy for this feature. 

#### What are the relevant tickets?
Closes #434, #433, #432, #430. 
