### PR TITLE
fix bug - unfinished reportback influencing new reportback flow, add tests

### DIFF
--- a/app/lib/reportback/index.js
+++ b/app/lib/reportback/index.js
@@ -127,7 +127,7 @@ function receivePhoto(doc, data) {
   }
   else {
     model.update(
-      {phone: data.phone},
+      {phone: data.phone, campaign: doc.campaign},
       {'$set': {photo: photoUrl}},
       function(err, num, raw) {
         if (!err) {
@@ -150,7 +150,7 @@ function receivePhoto(doc, data) {
 function receiveCaption(doc, data) {
   var answer = data.args;
   model.update(
-    {phone: data.phone},
+    {phone: data.phone, campaign: doc.campaign},
     {'$set': {caption: answer}},
     function(err, num, raw) {
       if (!err) {
@@ -172,7 +172,7 @@ function receiveCaption(doc, data) {
 function receiveQuantity(doc, data) {
   var answer = data.args;
   model.update(
-    {phone: data.phone},
+    {phone: data.phone, campaign: doc.campaign},
     {'$set': {quantity: answer}},
     function(err, num, raw) {
       if (!err) {
@@ -194,7 +194,7 @@ function receiveQuantity(doc, data) {
 function receiveWhyImportant(doc, data) {
   var answer = data.args;
   model.update(
-    {phone: data.phone},
+    {phone: data.phone, campaign: doc.campaign},
     {'$set': {why_important: answer}},
     function(err, num, raw) {
       if (!err) {

--- a/app/lib/reportback/test/reportback.test.js
+++ b/app/lib/reportback/test/reportback.test.js
@@ -8,24 +8,23 @@ var assert = require('assert')
 function test() {
   var TEST_PHONE = '15555555555'
     , TEST_CAMPAIGN_CONFIG = app.getConfig(app.ConfigName.REPORTBACK, 'test', 'endpoint')
-    , testDoc // exists in the global test scope; variable re-assigned each time createTestDoc() is run. 
-    ; 
+    , TEST_CAMPAIGN_CONFIG_2 = app.getConfig(app.ConfigName.REPORTBACK, 'test2', 'endpoint')
+    ;
 
-  var createTestDoc = function(done) {
-    model.create({phone: TEST_PHONE, campaign: TEST_CAMPAIGN_CONFIG.endpoint}, function(err, doc) {
-      if (doc) {
-        testDoc = doc;
-        done();
-      }
-    });
-  };
-
-  var removeTestDoc = function() {
+  var removeTestDocs = function() {
     model.remove({phone: TEST_PHONE}).exec();
   };
 
   describe('reportback.findDocument', function() {
-    before(createTestDoc);
+    var testDoc;
+    before(function(done) {
+      model.create({phone: TEST_PHONE, campaign: TEST_CAMPAIGN_CONFIG.endpoint}, function(err, doc) {
+        if (doc) {
+          testDoc = doc;
+          done();
+        }
+      });
+    });
 
     it('should find the document', function(done) {
       reportback.findDocument(TEST_PHONE, TEST_CAMPAIGN_CONFIG.endpoint)
@@ -39,7 +38,7 @@ function test() {
         });
     });
 
-    after(removeTestDoc);
+    after(removeTestDocs);
   });
 
   describe('reportback.onDocumentFound - when no existing document is found', function() {
@@ -61,7 +60,7 @@ function test() {
       });
     });
 
-    after(removeTestDoc);
+    after(removeTestDocs);
   });
 
   describe('reportback.receivePhoto - when no photo is sent', function() {
@@ -70,6 +69,15 @@ function test() {
         phone: TEST_PHONE,
         campaignConfig: TEST_CAMPAIGN_CONFIG
       };
+      var testDoc;
+      before(function(done) {
+        model.create({phone: TEST_PHONE, campaign: TEST_CAMPAIGN_CONFIG.endpoint}, function(err, doc) {
+          if (doc) {
+            testDoc = doc;
+            done();
+          }
+        });
+      });
 
       emitter.on(emitter.events.mcProfileUpdateTest, function(evtData) {
         if (evtData.form.phone_number == testData.phone &&
@@ -95,8 +103,15 @@ function test() {
       campaignConfig: TEST_CAMPAIGN_CONFIG,
       mms_image_url: 'http://test.url'
     };
-
-    before(createTestDoc);
+    var testDoc;
+    before(function(done) {
+      model.create({phone: TEST_PHONE, campaign: TEST_CAMPAIGN_CONFIG.endpoint}, function(err, doc) {
+        if (doc) {
+          testDoc = doc;
+          done();
+        }
+      });
+    });
 
     it('should respond with the "caption" message', function(done) {
       var mcEventDone = false;
@@ -141,7 +156,7 @@ function test() {
     });
 
     after(function() {
-      removeTestDoc();
+      removeTestDocs();
       emitter.removeAllListeners(emitter.events.mcProfileUpdateTest);
       emitter.removeAllListeners(emitter.events.reportbackModelUpdate);
     });
@@ -153,10 +168,18 @@ function test() {
       campaignConfig: TEST_CAMPAIGN_CONFIG,
       args: 'test caption'
     };
-
-    before(createTestDoc);
+    var testDoc;
+    before(function(done) {
+      model.create({phone: TEST_PHONE, campaign: TEST_CAMPAIGN_CONFIG.endpoint}, function(err, doc) {
+        if (doc) {
+          testDoc = doc;
+          done();
+        }
+      });
+    });
 
     it('should respond with the "quantity" message and update reportback doc with "test caption"', function(done) {
+
       var mcEventDone = false;
       var rbEventDone = false;
       function onSuccessfulEvent(evt) {
@@ -200,7 +223,7 @@ function test() {
     });
 
     after(function() {
-      removeTestDoc();
+      removeTestDocs();
       emitter.removeAllListeners(emitter.events.mcProfileUpdateTest);
       emitter.removeAllListeners(emitter.events.reportbackModelUpdate);
     });
@@ -212,8 +235,15 @@ function test() {
       campaignConfig: TEST_CAMPAIGN_CONFIG,
       args: '5'
     };
-
-    before(createTestDoc);
+    var testDoc;
+    before(function(done) {
+      model.create({phone: TEST_PHONE, campaign: TEST_CAMPAIGN_CONFIG.endpoint}, function(err, doc) {
+        if (doc) {
+          testDoc = doc;
+          done();
+        }
+      });
+    });
 
     it('should respond with the "why" message and update reportback doc with 5', function(done) {
       var mcEventDone = false;
@@ -259,7 +289,7 @@ function test() {
     });
 
     after(function() {
-      removeTestDoc();
+      removeTestDocs();
       emitter.removeAllListeners(emitter.events.mcProfileUpdateTest);
       emitter.removeAllListeners(emitter.events.reportbackModelUpdate);
     });
@@ -271,8 +301,15 @@ function test() {
       campaignConfig: TEST_CAMPAIGN_CONFIG,
       args: 'because I care'
     };
-
-    before(createTestDoc);
+    var testDoc;
+    before(function(done) {
+      model.create({phone: TEST_PHONE, campaign: TEST_CAMPAIGN_CONFIG.endpoint}, function(err, doc) {
+        if (doc) {
+          testDoc = doc;
+          done();
+        }
+      });
+    });
 
     it('should respond with the "completion" message and update reportback doc with the answer and optout of the campaign', function(done) {
       var mcUpdateEventDone = false;
@@ -334,12 +371,141 @@ function test() {
     });
 
     after(function() {
-      removeTestDoc();
+      removeTestDocs();
       emitter.removeAllListeners(emitter.events.mcProfileUpdateTest);
       emitter.removeAllListeners(emitter.events.mcOptoutTest);
       emitter.removeAllListeners(emitter.events.reportbackModelUpdate);
     });
   });
+  describe('A single user not finishing her reportback for one campaign before reporting back for another', function() {
+
+    // Documents updated as we simulate a user moving through the rb flow.
+    var testDoc1, testDoc2;
+    before(function(done) {
+      model.create({phone: TEST_PHONE, campaign: TEST_CAMPAIGN_CONFIG.endpoint}, {phone: TEST_PHONE, campaign: TEST_CAMPAIGN_CONFIG_2.endpoint}, function(err, doc1, doc2) {
+        if (doc1 && doc2) {
+          testDoc1 = doc1;
+          testDoc2 = doc2;
+          done();
+          console.log('testDoc1', testDoc1, 'testDoc2', testDoc2)
+        }
+      });
+    })
+
+    afterEach(function() {
+      emitter.removeAllListeners(emitter.events.reportbackModelUpdate);
+    })
+
+    it('should allow a user to send a photo for test campaign 1', function(done) {
+      var photoData = {
+        phone: TEST_PHONE,
+        campaignConfig: TEST_CAMPAIGN_CONFIG,
+        mms_image_url: 'http://test1.url'
+      };
+
+      emitter.on(emitter.events.reportbackModelUpdate, function(evtData) {
+        model.findOne({phone: TEST_PHONE, campaign: TEST_CAMPAIGN_CONFIG.endpoint}, function(err, doc) {
+          if (doc && doc.photo == photoData.mms_image_url) {
+            testDoc1 = doc;
+            done();
+          }
+        })
+      })
+      reportback.handleUserResponse(testDoc1, photoData);
+    })
+
+    it('should allow a user to send a caption for test campaign 1', function(done) {
+      var captionData = {
+        phone: TEST_PHONE,
+        campaignConfig: TEST_CAMPAIGN_CONFIG,
+        args: 'The arc of history is long but it bends towards justice'
+      }
+
+      emitter.on(emitter.events.reportbackModelUpdate, function(evtData) {
+        model.findOne({phone: TEST_PHONE, campaign: TEST_CAMPAIGN_CONFIG.endpoint}, function(err, doc) {
+          if (doc && doc.caption == captionData.args) {
+            testDoc1 = doc;
+            done();
+          }
+        })
+      })
+      reportback.handleUserResponse(testDoc1, captionData);
+    })
+
+    it('should allow a user to send in a quantity for test campaign 1', function(done) {
+      var quantityData = {
+        phone: TEST_PHONE,
+        campaignConfig: TEST_CAMPAIGN_CONFIG,
+        args: 888888888
+      }
+
+      emitter.on(emitter.events.reportbackModelUpdate, function(evtData) {
+        model.findOne({phone: TEST_PHONE, campaign: TEST_CAMPAIGN_CONFIG.endpoint}, function(err, doc) {
+          if (doc && doc.quantity == quantityData.args) {
+            testDoc1 = doc;
+            done();
+          }
+        })
+      })
+      reportback.handleUserResponse(testDoc1, quantityData);
+    })
+
+    it('should allow a user to send a photo for test campaign 2', function(done) {
+      var photoData = {
+        phone: TEST_PHONE,
+        campaignConfig: TEST_CAMPAIGN_CONFIG_2,
+        mms_image_url: 'http://testcampaigntwo.url'
+      };
+
+      emitter.on(emitter.events.reportbackModelUpdate, function(evtData) {
+        model.findOne({phone: TEST_PHONE, campaign: TEST_CAMPAIGN_CONFIG_2.endpoint}, function(err, doc) {
+          if (doc && doc.photo == photoData.mms_image_url) {
+            testDoc2 = doc;
+            done();
+          }
+        })
+      })
+      reportback.handleUserResponse(testDoc2, photoData);
+    })
+
+    it('should allow a user to send a caption for test campaign 2', function(done) {
+      var captionData = {
+        phone: TEST_PHONE,
+        campaignConfig: TEST_CAMPAIGN_CONFIG_2,
+        args: 'Friends, Romans, countrymen lend me your ears!'
+      }
+
+      emitter.on(emitter.events.reportbackModelUpdate, function(evtData) {
+        model.findOne({phone: TEST_PHONE, campaign: TEST_CAMPAIGN_CONFIG_2.endpoint}, function(err, doc) {
+          if (doc && doc.caption == captionData.args) {
+            testDoc2 = doc;
+            done();
+          }
+        })
+      })
+      reportback.handleUserResponse(testDoc2, captionData);
+    })
+
+    it('should allow a user to send in a quantity for test campaign 2', function(done) {
+      var quantityData = {
+        phone: TEST_PHONE,
+        campaignConfig: TEST_CAMPAIGN_CONFIG_2,
+        args: 777777777
+      }
+
+      emitter.on(emitter.events.reportbackModelUpdate, function(evtData) {
+        model.findOne({phone: TEST_PHONE, campaign: TEST_CAMPAIGN_CONFIG_2.endpoint}, function(err, doc) {
+          if (doc && doc.quantity == quantityData.args) {
+            testDoc2 = doc;
+            done();
+          }
+        })
+      })
+      reportback.handleUserResponse(testDoc2, quantityData);
+    })
+
+    after(removeTestDocs);
+  })
 };
 
 module.exports = test;

--- a/app/lib/reportback/test/reportback.test.js
+++ b/app/lib/reportback/test/reportback.test.js
@@ -6,12 +6,15 @@ var assert = require('assert')
   ;
 
 function test() {
-  var TEST_PHONE = '15555555555';
-  var TEST_CAMPAIGN_CONFIG = app.getConfig(app.ConfigName.REPORTBACK, 'test', 'endpoint');
+  var TEST_PHONE = '15555555555'
+    , TEST_CAMPAIGN_CONFIG = app.getConfig(app.ConfigName.REPORTBACK, 'test', 'endpoint')
+    , testDoc // exists in the global test scope; variable re-assigned each time createTestDoc() is run. 
+    ; 
 
   var createTestDoc = function(done) {
     model.create({phone: TEST_PHONE, campaign: TEST_CAMPAIGN_CONFIG.endpoint}, function(err, doc) {
       if (doc) {
+        testDoc = doc;
         done();
       }
     });
@@ -63,7 +66,6 @@ function test() {
 
   describe('reportback.receivePhoto - when no photo is sent', function() {
     it('should respond with the "not a photo" message', function(done) {
-      var testDoc = {};
       var testData = {
         phone: TEST_PHONE,
         campaignConfig: TEST_CAMPAIGN_CONFIG
@@ -88,7 +90,6 @@ function test() {
   });
 
   describe('reportback.receivePhoto - when a photo is sent', function() {
-    var testDoc = {};
     var testData = {
       phone: TEST_PHONE,
       campaignConfig: TEST_CAMPAIGN_CONFIG,
@@ -135,7 +136,6 @@ function test() {
           }
         });
       });
-
       // Call receivePhoto with test data
       reportback.receivePhoto(testDoc, testData);
     });
@@ -148,7 +148,6 @@ function test() {
   });
 
   describe('reportback.receiveCaption - with a value of "test caption"', function() {
-    var testDoc = {};
     var testData = {
       phone: TEST_PHONE,
       campaignConfig: TEST_CAMPAIGN_CONFIG,
@@ -208,7 +207,6 @@ function test() {
   });
 
   describe('reportback.receiveQuantity - with a value of 5', function() {
-    var testDoc = {};
     var testData = {
       phone: TEST_PHONE,
       campaignConfig: TEST_CAMPAIGN_CONFIG,
@@ -268,7 +266,6 @@ function test() {
   });
 
   describe('reportback.receiveWhyImportant - with a value of "because I care"', function() {
-    var testDoc = {};
     var testData = {
       phone: TEST_PHONE,
       campaignConfig: TEST_CAMPAIGN_CONFIG,


### PR DESCRIPTION
#### What's this PR do?
Previously, if a reportback DB document was created but the reportback was never submitted/finished by the user, it was never destroyed and thus lingered in the database. 

If a user didn't finish a reportback flow, but then wanted to reportback into another campaign, our app would sometimes find their previous unfinished reportback documents and update those documents, messing up the new reportback flow. 

This PR adds a new, campaign-specific param to our DB calls to eliminate this interference. 

#### Where should the reviewer start?
`reportback/index.js` contains the modified code. 

#### How should this be manually tested?
By beginning a reportback flow (1/3 Postman collection [here](https://www.getpostman.com/collections/71bd60b99e46cc8ce514
)), stopping at any stage before you submit the reportback, and then creating a new reportback flow. (Comeback Clothes Postman collection [here](https://www.getpostman.com/collections/8ce30f8111deea794ba9)). 

Created #443 to add test coverage. 

#### What are the relevant tickets?
Closes #442, #443. 
