### PR TITLE
add reportback permalink functionality

### DIFF
--- a/app/eventEmitter.js
+++ b/app/eventEmitter.js
@@ -7,7 +7,8 @@ events.EventEmitter.prototype.events = {
   mcOptinTest: 'mobilecommons-optin-test',
   mcOptoutTest: 'mobilecommons-optout-test',
   mcProfileUpdateTest: 'mobilecommons-profile-update-test',
-  reportbackModelUpdate: 'reportback-model-update'
+  reportbackModelUpdate: 'reportback-model-update',
+  reportbackSubmit: 'reportback-submit'
 };
 
 module.exports = eventEmitter;

--- a/app/lib/ds-content-api/index.js
+++ b/app/lib/ds-content-api/index.js
@@ -5,7 +5,10 @@ var request = require('request')
   , emitter = rootRequire('app/eventEmitter')
   ;
 
-var BASE_URL;
+var BASE_URL
+  , TEST_RBID = 100
+  ;
+
 var VERSION = 'v1';
 if (process.env.NODE_ENV == 'production') {
   BASE_URL = 'https://www.dosomething.org/api/' + VERSION;
@@ -26,7 +29,8 @@ module.exports = function() {
     userLogout: userLogout,
     authToken: authToken,
     campaignsReportback: campaignsReportback,
-    systemConnect: systemConnect
+    systemConnect: systemConnect,
+    TEST_RBID: TEST_RBID
   };
 };
 
@@ -306,11 +310,11 @@ function campaignsReportback(rbData, callback) {
     _callback = onCampaignsReportback.bind({customCallback: callback});
   }
 
-  // If we're in a test env, just log and emit an event. 
+  // If we're in a test env, just log, emit an event, and call the callback function with test values. 
   if (process.env.NODE_ENV == 'test') {
     logger.info('dscontentapi.campaignsReportback test: ', body.uid, ' | ', body.caption, ' | ', body.quantity, ' | ', body.why_participated, ' | ', body.file_url);
     emitter.emit(emitter.events.reportbackSubmit, options);
-    return callback(null, ['100'], ['100']);
+    return callback(null, [TEST_RBID], [TEST_RBID]);
   }
 
   var requestRetry = new RequestRetry();

--- a/app/lib/ds-content-api/index.js
+++ b/app/lib/ds-content-api/index.js
@@ -2,6 +2,7 @@ var request = require('request')
   , crypto = require('crypto')
   , logger = rootRequire('app/lib/logger')
   , RequestRetry = require('node-request-retry')
+  , emitter = rootRequire('app/eventEmitter')
   ;
 
 var BASE_URL;
@@ -303,6 +304,13 @@ function campaignsReportback(rbData, callback) {
   var _callback = onCampaignsReportback;
   if (typeof callback === 'function') {
     _callback = onCampaignsReportback.bind({customCallback: callback});
+  }
+
+  // If we're in a test env, just log and emit an event. 
+  if (process.env.NODE_ENV == 'test') {
+    logger.info('dscontentapi.campaignsReportback test: ', body.uid, ' | ', body.caption, ' | ', body.quantity, ' | ', body.why_participated, ' | ', body.file_url);
+    emitter.emit(emitter.events.reportbackSubmit, options);
+    return callback(null, ['100'], ['100']);
   }
 
   var requestRetry = new RequestRetry();

--- a/app/lib/reportback/index.js
+++ b/app/lib/reportback/index.js
@@ -10,8 +10,15 @@ var express = require('express')
   , emitter = rootRequire('app/eventEmitter')
   , logger = rootRequire('app/lib/logger')
   , dscontentapi = rootRequire('app/lib/ds-content-api')()
-  , REPORTBACK_PERMALINK_BASE_URL = 'https://www.dosomething.org/reportback/'
+  , REPORTBACK_PERMALINK_BASE_URL
   ;
+
+if (process.env.NODE_ENV == 'production') {
+  REPORTBACK_PERMALINK_BASE_URL = 'https://www.dosomething.org/reportback/';
+}
+else {
+  REPORTBACK_PERMALINK_BASE_URL = 'http://staging.beta.dosomething.org/reportback/';
+}
 
 router.post('/:campaign', function(request, response) {
   var campaign
@@ -382,5 +389,5 @@ if (process.env.NODE_ENV === 'test') {
   module.exports.receivePhoto = receivePhoto;
   module.exports.receiveQuantity = receiveQuantity;
   module.exports.receiveWhyImportant = receiveWhyImportant;
-  // module.exports.completeReportBack = completeReportBack;
+  module.exports.REPORTBACK_PERMALINK_BASE_URL = REPORTBACK_PERMALINK_BASE_URL;
 }

--- a/app/lib/reportback/test/reportback.test.js
+++ b/app/lib/reportback/test/reportback.test.js
@@ -387,7 +387,6 @@ function test() {
           testDoc1 = doc1;
           testDoc2 = doc2;
           done();
-          console.log('testDoc1', testDoc1, 'testDoc2', testDoc2)
         }
       });
     })

--- a/app/lib/reportback/test/reportback.test.js
+++ b/app/lib/reportback/test/reportback.test.js
@@ -3,6 +3,7 @@ var assert = require('assert')
   , connectionOperations = rootRequire('app/config/connectionOperations')
   , model = require('../reportbackModel')(connectionOperations)
   , emitter = rootRequire('app/eventEmitter')
+  , dscontentapi = rootRequire('app/lib/ds-content-api')()
   ;
 
 function test() {
@@ -335,7 +336,8 @@ function test() {
       // Check if correct user is subscribed to correct opt-in path
       emitter.on(emitter.events.mcProfileUpdateTest, function(evtData) {
         if (evtData.form.phone_number == testData.phone &&
-            evtData.form.opt_in_path_id == TEST_CAMPAIGN_CONFIG.message_complete) {
+            evtData.form.opt_in_path_id == TEST_CAMPAIGN_CONFIG.message_complete &&
+            evtData.form.last_reportback_url == reportback.REPORTBACK_PERMALINK_BASE_URL + dscontentapi.TEST_RBID) { 
           onSuccessfulEvent(emitter.events.mcProfileUpdateTest);
         }
         else {


### PR DESCRIPTION
#### What's this PR do?
This adds permalink functionality in reportbacks. That is, when a user finishes a reportback flow by texting back an answer to the question "why is completing this campaign important to you", the completion message they receive contains a url to their custom reportback page. 

#### Where should the reviewer start?
The reviewer should start at `app/lib/reportback/index.js`, where the function handling the reportback flow has been updated. 

#### How should this be manually tested?
`npm test`. 

Additionally, use the postman collection below to test with a test reportback flow already set up to return a message with your reportback link: 
```
{"id":"d56424ac-049d-f38d-35da-02ad8327057e","name":"SMS Report Backs - Test","timestamp":1431641139202,"requests":[{"collectionId":"d56424ac-049d-f38d-35da-02ad8327057e","id":"031d50e6-a7af-fd73-878b-857435224553","name":"4) Send why important?","description":"","url":"http://localhost:4711/reportback/test","method":"POST","headers":"","data":[{"key":"phone","value":"15555551000","type":"text"},{"key":"args","value":"Because tests are testy. ","type":"text"}],"dataMode":"urlencoded","timestamp":0,"version":2,"time":1432130383988},{"collectionId":"d56424ac-049d-f38d-35da-02ad8327057e","id":"2340bea7-9f74-704b-ee18-fd3445d85879","name":"3) Send Quantity","description":"","url":"http://localhost:4711/reportback/test","method":"POST","headers":"","data":[{"key":"phone","value":"15555551000","type":"text"},{"key":"args","value":"6789","type":"text"}],"dataMode":"urlencoded","timestamp":0,"version":2,"time":1432130378234},{"collectionId":"d56424ac-049d-f38d-35da-02ad8327057e","id":"bd31bb4c-76b4-6cdf-e27a-ca5f2d205b6d","name":"2) Send Caption","description":"","url":"http://localhost:4711/reportback/test","method":"POST","headers":"","data":[{"key":"phone","value":"15555551000","type":"text"},{"key":"args","value":"goose egg. ","type":"text"}],"dataMode":"urlencoded","timestamp":0,"version":2,"time":1432130375240},{"collectionId":"d56424ac-049d-f38d-35da-02ad8327057e","id":"f4398800-b330-440a-2998-82081ae13674","name":"1) Send Photo","description":"","url":"http://localhost:4711/reportback/test","method":"POST","headers":"","data":[{"key":"phone","value":"15555551000","type":"text"},{"key":"args","value":"","type":"text"},{"key":"mms_image_url","value":"https://avatars2.githubusercontent.com/u/5678066?v=2&s=460","type":"text"}],"dataMode":"urlencoded","timestamp":0,"version":2,"time":1432130371656}]}
``` 
#### Any background context you want to provide?
A new custom user profile field has been added to Mobile Commons: `last_reportback_url`. 

This is the field that's updated with the reportback URL when a user completes a reportback. We'll need to make sure that the mobile product team updates the final reportback completed message with this property in liquid. 

#### What are the relevant tickets?
Closes #454. 