### PR TITLE
Issue 470: reportback quantity validations

### DIFF
--- a/app/lib/reportback/index.js
+++ b/app/lib/reportback/index.js
@@ -13,6 +13,7 @@ var express = require('express')
   , REPORTBACK_PERMALINK_BASE_URL
   , shortenLink = rootRequire('app/lib/bitly')
   , Q = require('q')
+  , parseForDigits = require('count-von-count')
   ;
 
 if (process.env.NODE_ENV == 'production') {
@@ -180,17 +181,24 @@ function receiveCaption(doc, data) {
  *   Data from the user's request
  */
 function receiveQuantity(doc, data) {
+  debugger;
   var answer = data.args;
-  model.update(
-    {phone: data.phone, campaign: doc.campaign},
-    {'$set': {quantity: answer}},
-    function(err, num, raw) {
-      if (!err) {
-        emitter.emit(emitter.events.reportbackModelUpdate);
-      }
-    });
-
-  mobilecommons.profile_update(data.phone, data.campaignConfig.message_why);
+  var quantity = parseForDigits(answer);
+  debugger;
+  if (quantity) {
+    model.update(
+      {phone: data.phone, campaign: doc.campaign},
+      {'$set': {quantity: quantity}},
+      function(err, num, raw) {
+        if (!err) {
+          emitter.emit(emitter.events.reportbackModelUpdate);
+        }
+      });
+    mobilecommons.profile_update(data.phone, data.campaignConfig.message_why);
+  }
+  else {
+    mobilecommons.profile_update(data.phone, data.campaignConfig.message_quantity_sent_invalid);
+  }
 }
 
 /**

--- a/app/lib/reportback/index.js
+++ b/app/lib/reportback/index.js
@@ -181,10 +181,8 @@ function receiveCaption(doc, data) {
  *   Data from the user's request
  */
 function receiveQuantity(doc, data) {
-  debugger;
   var answer = data.args;
   var quantity = parseForDigits(answer);
-  debugger;
   if (quantity) {
     model.update(
       {phone: data.phone, campaign: doc.campaign},

--- a/app/lib/reportback/reportbackConfigModel.js
+++ b/app/lib/reportback/reportbackConfigModel.js
@@ -25,6 +25,9 @@ var rbSchema = new mongoose.Schema({
   // Mobile Commons opt-in path ID to ask for photo caption
   message_caption: Number,
 
+  // Mobile Commons opt-in path ID of the error message indicating that the quantity submitted is invalid
+  message_quantity_sent_invalid: Number,
+
   // Mobile Commons opt-in path ID to ask for quantity
   message_quantity: Number,
 

--- a/app/lib/reportback/test/reportback.test.js
+++ b/app/lib/reportback/test/reportback.test.js
@@ -230,6 +230,52 @@ function test() {
     });
   });
 
+  describe('reportback.receiveQuantity - receives invalid quantity value', function() {
+
+    var testData = {
+      phone: TEST_PHONE,
+      campaignConfig: TEST_CAMPAIGN_CONFIG,
+      args: 'this is not a number in any way'
+    };
+
+    var testDoc;
+    before(function(done) {
+      model.create({phone: TEST_PHONE, campaign: TEST_CAMPAIGN_CONFIG.endpoint}, function(err, doc) {
+        if (doc) {
+          testDoc = doc;
+          done();
+        }
+      });
+    });
+
+    it('should respond with the "quantity sent invalid" message', function(done) {
+      emitter.on(emitter.events.mcProfileUpdateTest, function(evtData) {
+        if (evtData.form.phone_number == testData.phone &&
+            evtData.form.opt_in_path_id == TEST_CAMPAIGN_CONFIG.message_quantity_sent_invalid) {
+          done();
+        }
+        else {
+          assert(false);
+        }
+      });
+
+      // If model is updated, test fails. 
+      emitter.on(emitter.events.reportbackModelUpdate, function() {
+        assert(false);
+      });
+
+      // Call receiveQuantity with test data
+      reportback.receiveQuantity(testDoc, testData);
+    })
+
+    after(function() {
+      removeTestDocs();
+      emitter.removeAllListeners(emitter.events.mcProfileUpdateTest);
+      emitter.removeAllListeners(emitter.events.reportbackModelUpdate);
+    });
+
+  })
+
   describe('reportback.receiveQuantity - with a value of 5', function() {
     var testData = {
       phone: TEST_PHONE,

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "body-parser": "^1.9.2",
     "connect-multiparty": "1.1.0",
+    "count-von-count": "^1.0.0",
     "coveralls": "^2.11.2",
     "errorhandler": "^1.2.2",
     "express": "^4.10.2",


### PR DESCRIPTION
#### What's this PR do?
Adds a [library](https://github.com/DoSomething/count-von-count) which filters a text string for numbers and spelled numbers, and converts those numbers to digits. 

This library is added to the reportback flow, where the user-submitted response for the "quantity done" question is then filtered for digits before being submitted to the reportback API. 

If a response with no numbers is submitted, the user receives an error message, which has been added to the reportback config do. 

#### Where should the reviewer start?
`npm test` validates whether the user receives the `message_quantity_sent_invalid` message after submitting an invalid message. 

The [library](https://github.com/DoSomething/count-von-count) contains its own tests, and its validity can be tested independently. 

This functionality can also be tested with [this postman collection](https://www.getpostman.com/collections/2abbad22b2d79005366e). 

#### How should this be manually tested?
`npm test`. 

#### Any background context you want to provide?
When receiving a reportback submission through its API, the Drupal DoSomething app doesn't accept anything other than digits--"1", "2"--for the quantity of things done. 

Previously, if a user submitted a non-digit response during the "quantity" question of the SMS reportback flow--i.e., if a user submitted "one" instead of "1"--the DoSomething app would interpret that as "0". 

This became problematic during campaigns like "I Heart Dad". When users were asked "how many dads did you measure the blood pressure", a large percentage of users responded with "the only one I have" or "one". 

#### What are the relevant tickets?
Closes #470. 