### PR TITLE
add timestamps to betas joining

### DIFF
--- a/app/lib/sms-games/controllers/SGCompetitiveStoryController.js
+++ b/app/lib/sms-games/controllers/SGCompetitiveStoryController.js
@@ -118,6 +118,7 @@ SGCompetitiveStoryController.prototype.createGame = function(request, response) 
       gameDoc.betas[idx].invite_accepted = false;
       gameDoc.betas[idx].phone = phone;
       gameDoc.betas[idx].name = shortName || phone;
+      gameDoc.betas[idx].time_joined = 0;
     }
   }
 

--- a/app/lib/sms-games/controllers/logicBetaJoin.js
+++ b/app/lib/sms-games/controllers/logicBetaJoin.js
@@ -36,6 +36,7 @@ module.exports = function(request, doc) {
   for (var i = 0; i < doc.betas.length; i++) {
     if (doc.betas[i].phone == joiningBetaPhone) {
       doc.betas[i].invite_accepted = true;
+      doc.betas[i].time_joined = new Date();
       break;
     }
   }

--- a/app/lib/sms-games/models/sgGameSchema.js
+++ b/app/lib/sms-games/models/sgGameSchema.js
@@ -21,7 +21,11 @@ var sgGameSchema = new mongoose.Schema({
     name: String,
 
     // Phone number of the beta user
-    phone: String
+    phone: String,
+
+    // Time when beta joins
+    time_joined: 0
+
   }]
 })
 


### PR DESCRIPTION
#### What's this PR do?
When a beta joins a game, we mark this event in our game doc with a timestamp. Will help us, in the future, to determine the median amount of time it takes for a beta to join the game. 

#### How should this be manually tested?
Creating a game, having a beta joining a game, and then confirming in the database that a date has been added. 

#### What are the relevant tickets?
Closes #473. 