### PR TITLE
reduce end level wait time for messages

### DIFF
--- a/app/lib/sms-games/controllers/logicUserAction.js
+++ b/app/lib/sms-games/controllers/logicUserAction.js
@@ -11,11 +11,11 @@ var smsHelper = rootRequire('app/lib/smsHelpers')
   ;
 
 // Delay (in milliseconds) for end level group messages to be sent.
-var END_LEVEL_GROUP_MESSAGE_DELAY = 15000
+var END_LEVEL_GROUP_MESSAGE_DELAY = 4000
 // Delay (in milliseconds) for next level start messages to be sent.
-  , NEXT_LEVEL_START_DELAY = 30000
+  , NEXT_LEVEL_START_DELAY = 6000
 // Delay for next level player name messages to be sent. 
-  , END_LEVEL_PLAYER_NAME_MESSAGE_DELAY = 7500
+  , END_LEVEL_PLAYER_NAME_MESSAGE_DELAY = 2000
 // StatHat analytics marker. 
   , STATHAT_CATEGORY = 'sms-games'
 


### PR DESCRIPTION
#### What's this PR do?
Pretty self-explanatory. Reduces the time between end-level messages and start messages--got a lot of feedback from intern testers that the delays between levels (30 seconds until the next level's first message) were too long. Tested on my local with my own phone, messages are sent in order. 

#### What are the relevant tickets?
Closes #474. 