### PR TITLE
bug fix: creating subsequent games from mobile

### DIFF
--- a/app/lib/sms-games/config/competitiveStoriesConfigModel.js
+++ b/app/lib/sms-games/config/competitiveStoriesConfigModel.js
@@ -66,13 +66,13 @@ var competitiveStoriesConfigSchema = new mongoose.Schema({
     ask_beta_2_oip: Number, 
 
     // Error message informing alpha she did not provide a valid name for herself. 
-    invalid_alpha_first_name: Number,
+    invalid_alpha_first_name_oip: Number,
 
     // Error message informing alpha she provided an invalid mobile number. 
     invalid_mobile_oip: Number,
 
     // Error message informing that the alpha has not provided enough numbers (>=1) for the game to begin. 
-    not_enough_players_oip: Number,
+    not_enough_players_oip: Number
 
   },
 

--- a/app/lib/sms-games/controllers/SGCreateFromMobileController.js
+++ b/app/lib/sms-games/controllers/SGCreateFromMobileController.js
@@ -55,7 +55,6 @@ SGCreateFromMobileController.prototype.processRequest = function(request, respon
   }
 
   self = this;
-  self.createGame = createGame;
   request = request;
   response = response;
   gameConfig = app.getConfig(gameConfigNameString, request.query.story_id);
@@ -65,109 +64,105 @@ SGCreateFromMobileController.prototype.processRequest = function(request, respon
     return false;
   }
 
-  // Query for the game creation config doc most recently created by this user.
-  var queryConfig = configModel.find({alpha_mobile: request.body.phone, story_id: request.query.story_id}).sort({created_at: -1}).limit(1);
-  var promiseConfig = queryConfig.exec();
-
-  promiseConfig.then(function(configDocs) {
-    // If no document has been created by this user, then create one. This game creation config doc 
-    // should NOT be confused with the game doc, or the gameConfig. It's destroyed
-    // after the game is begun; it's used only for game creation. 
-    if (configDoc == null) {
-      // We don't ask for the first name yet, so just saving it as phone for now.
-      var doc = {
-        alpha_mobile: request.body.phone,
-        story_id: request.query.story_id,
-        story_type: request.query.story_type,
-        game_type: (request.query.game_type || '')
-      };
-
-      // User should have responded with the alpha name.
-      var message = request.body.args;
-      if (smsHelper.hasLetters(message)) {
-        doc.alpha_first_name = smsHelper.getLetters(message);
-        // Send next message asking for beta_mobile_1.
-        sendSMS(request.body.phone, gameConfig.mobile_create.ask_beta_0_oip);
-      }
-      else {
-        // If user responded with something else, ask for a valid player name. 
-        sendSMS(request.body.phone, gameConfig.mobile_create.invalid_alpha_first_name);
-      }
-      var createGame = configModel.create(doc);
-      createGame.then(function(doc) {
+  // If the request query params contain the 'alpha_first_name_query_response' param, 
+  // check whether or not we should create a new create game config. 
+  // (not to be confused with the game doc, or the gameConfig--it's destroyed after
+  // the game is begun; it's only used for game creation.)
+  if (request.query.alpha_first_name_query_response) {
+    var doc = {
+      alpha_mobile: request.body.phone,
+      story_id: request.query.story_id,
+      story_type: request.query.story_type,
+      game_type: (request.query.game_type || '')
+    };
+    var message = request.body.args;
+    // User should have responded with the alpha name. If so, create game create config doc.
+    if (smsHelper.hasLetters(message)) {
+      doc.alpha_first_name = smsHelper.getLetters(message);
+      var createGameConfig = configModel.create(doc);
+      createGameConfig.then(function(doc) {
         emitter.emit('game-create-config-created', doc);
       })
+      // Send next message asking for beta_mobile_1.
+      sendSMS(request.body.phone, gameConfig.mobile_create.ask_beta_0_oip);
     }
-    // If a document is found, then process the user message.
     else {
-      var message = request.body.args;
-      // Create the game if we have at least one beta number.
-      // If the alpha responds 'Y' to the 'create game now?' query. 
-      if (smsHelper.isYesResponse(message)) {
-        if (configDoc.beta_mobile_0 && smsHelper.isValidPhone(configDoc.beta_mobile_0)) {
-          emitter.emit('mobile-create-flow-creating-game', configDoc)
-          // While it may seem that the two calls below may produce asynchronous weirdness, they don't. 
-          self.createGame(configDoc, self.host);
-          self._removeDocument(configDoc.alpha_mobile);
-        }
-        else {
-          // Send the "not enough players" message.
-          sendSMS(configDoc.alpha_mobile, gameConfig.mobile_create.not_enough_players_oip);
-        }
-      }
-      // If the alpha hasn't yet provided a valid name yet. 
-      else if (!configDoc.alpha_first_name) {
-        if (smsHelper.hasLetters(message)) {
-          var alphaName = smsHelper.getLetters(message);
-          configDoc.alpha_first_name = alphaName;
-          self._updateDocument(configDoc);
-          sendSMS(configDoc.alpha_mobile, gameConfig.mobile_create.ask_beta_0_oip);
-        }
-        else {
-          sendSMS(configDoc.alpha_mobile, gameConfig.mobile_create.invalid_alpha_first_name);
-        }
-      }
-      // If the message contains a valid phone number and beta name. 
-      else if (isPhoneNumber(message) && smsHelper.hasLetters(message)) {
-        var betaMobile = smsHelper.getNormalizedPhone(message);
-        var betaName = smsHelper.getLetters(message);
-
-        // If we haven't saved a beta number yet, save it to beta_mobile_0.
-        if (!configDoc.beta_mobile_0 && !configDoc.beta_first_name_0) {
-          configDoc.beta_mobile_0 = betaMobile;
-          configDoc.beta_first_name_0 = betaName;
-          self._updateDocument(configDoc);
-
-          // Then ask for beta_mobile_1.
-          sendSMS(configDoc.alpha_mobile, gameConfig.mobile_create.ask_beta_1_oip);
-        }
-        // If we haven't saved the 2nd beta number yet, save it to beta_mobile_1.
-        else if (!configDoc.beta_mobile_1 && !configDoc.beta_first_name_1) {
-          configDoc.beta_mobile_1 = betaMobile;
-          configDoc.beta_first_name_1 = betaName;
-          self._updateDocument(configDoc);
-
-          // Then ask for beta_mobile_2.
-          sendSMS(configDoc.alpha_mobile, gameConfig.mobile_create.ask_beta_2_oip);
-        }
-        // At this point, this is the last number we need. So, create the game.
-        else {
-          configDoc.beta_mobile_2 = betaMobile;
-          configDoc.beta_first_name_2 = betaName;
-          // Again, while it may seem that the two calls below may produce async disorderlyness, they don't. 
-          emitter.emit('mobile-create-flow-creating-game', configDoc)
-          self.createGame(configDoc, self.host);
-          self._removeDocument(configDoc.alpha_mobile);
-        }
-      }
-      // Send the "invalid response" message.
-      else {
-        sendSMS(configDoc.alpha_mobile, gameConfig.mobile_create.invalid_mobile_oip);
-      }
+      // If user responded with something else, ask for a valid player name. 
+      sendSMS(request.body.phone, gameConfig.mobile_create.invalid_alpha_first_name_oip);
     }
-  }, function(err) {
-    logger.error(err);
-  })
+
+  }
+  // If the query params do not contain the `alpha_first_name_query_response` param, process the request otherwise.
+  else {
+    // Query for the game creation config doc most recently created by this user.
+    var queryConfig = configModel.find({alpha_mobile: request.body.phone, story_id: request.query.story_id}).sort({created_at: -1}).limit(1);
+    var promiseConfig = queryConfig.exec();
+
+    promiseConfig.then(function(configDocs) {
+      var configDoc = configDocs[0];
+      // If a document is found, then process the user message.
+      if (configDoc) {
+        var message = request.body.args;
+        // Create the game if we have at least one beta number.
+        // If the alpha responds 'Y' to the 'create game now?' query. 
+        if (smsHelper.isYesResponse(message)) {
+          if (configDoc.beta_mobile_0 && smsHelper.isValidPhone(configDoc.beta_mobile_0)) {
+            emitter.emit('mobile-create-flow-creating-game', configDoc)
+            // While it may seem that the two calls below may produce asynchronous weirdness, they don't. 
+            self._createGame(configDoc, self.host);
+            self._removeDocument(configDoc._id);
+          }
+          else {
+            // Send the "not enough players" message.
+            sendSMS(configDoc.alpha_mobile, gameConfig.mobile_create.not_enough_players_oip);
+          }
+        }
+        // If the message contains a valid phone number and beta name. 
+        else if (isPhoneNumber(message) && smsHelper.hasLetters(message)) {
+          var betaMobile = smsHelper.getNormalizedPhone(message);
+          var betaName = smsHelper.getLetters(message);
+
+          // If we haven't saved a beta number yet, save it to beta_mobile_0.
+          if (!configDoc.beta_mobile_0 && !configDoc.beta_first_name_0) {
+            configDoc.beta_mobile_0 = betaMobile;
+            configDoc.beta_first_name_0 = betaName;
+            self._updateDocument(configDoc);
+
+            // Then ask for beta_mobile_1.
+            sendSMS(configDoc.alpha_mobile, gameConfig.mobile_create.ask_beta_1_oip);
+          }
+          // If we haven't saved the 2nd beta number yet, save it to beta_mobile_1.
+          else if (!configDoc.beta_mobile_1 && !configDoc.beta_first_name_1) {
+            configDoc.beta_mobile_1 = betaMobile;
+            configDoc.beta_first_name_1 = betaName;
+            self._updateDocument(configDoc);
+
+            // Then ask for beta_mobile_2.
+            sendSMS(configDoc.alpha_mobile, gameConfig.mobile_create.ask_beta_2_oip);
+          }
+          // At this point, this is the last number we need. So, create the game.
+          else {
+            configDoc.beta_mobile_2 = betaMobile;
+            configDoc.beta_first_name_2 = betaName;
+            // Again, while it may seem that the two calls below may produce async disorderlyness, they don't. 
+            emitter.emit('mobile-create-flow-creating-game', configDoc)
+            self._createGame(configDoc, self.host);
+            self._removeDocument(configDoc._id);
+          }
+        }
+        // Send the "invalid response" message.
+        else {
+          sendSMS(configDoc.alpha_mobile, gameConfig.mobile_create.invalid_mobile_oip);
+        }
+      }
+      // If no config doc is found, then the user hasn't created one yet by texting in an alpha first name. Ask again.
+      else {
+        sendSMS(request.body.phone, gameConfig.mobile_create.invalid_alpha_first_name_oip);
+      }
+    }, function(err) {
+      logger.error(err);
+    })
+  }
   response.send();
 };
 
@@ -179,7 +174,7 @@ SGCreateFromMobileController.prototype.processRequest = function(request, respon
  * @param host
  *   Hostname of this app.
  */
-function createGame(gameCreateConfig, host) {
+SGCreateFromMobileController.prototype._createGame = function(gameCreateConfig, host) {
   var url = 'http://' + host + '/sms-multiplayer-game/create';
   var payload = {
     form: {
@@ -202,7 +197,7 @@ function createGame(gameCreateConfig, host) {
     }
 
     if (response && response.statusCode) {
-      logger.info('SGCreateFromMobileController.createGame: POST to ' + url + ' returned status code: ' + response.statusCode);
+      logger.info('SGCreateFromMobileController._createGame: POST to ' + url + ' returned status code: ' + response.statusCode);
     }
   });
 };
@@ -252,6 +247,7 @@ function ErrorAbortPromiseChain() {
  */
 SGCreateFromMobileController.prototype._updateDocument = function(configDoc) {
   var editedDoc = {
+      _id: configDoc._id,
       alpha_first_name: configDoc.alpha_first_name ? configDoc.alpha_first_name : null,
       beta_mobile_0: configDoc.beta_mobile_0 ? configDoc.beta_mobile_0 : null,
       beta_mobile_1: configDoc.beta_mobile_1 ? configDoc.beta_mobile_1 : null,
@@ -261,7 +257,7 @@ SGCreateFromMobileController.prototype._updateDocument = function(configDoc) {
       beta_first_name_2: configDoc.beta_first_name_2 ? configDoc.beta_first_name_2 : ''
     }
   configModel.update(
-    {alpha_mobile: configDoc.alpha_mobile},
+    {_id: configDoc._id},
     {$set: editedDoc},
     function(err, num, raw) {
       if (err) {
@@ -281,9 +277,9 @@ SGCreateFromMobileController.prototype._updateDocument = function(configDoc) {
  * @param phone
  *   Alpha mobile number.
  */
-SGCreateFromMobileController.prototype._removeDocument = function(phone) {
+SGCreateFromMobileController.prototype._removeDocument = function(id) {
   configModel.remove(
-    {alpha_mobile: phone},
+    {_id: id},
     function(err, num) {
       if (err) {
         logger.error(err);

--- a/app/lib/sms-games/controllers/SGCreateFromMobileController.js
+++ b/app/lib/sms-games/controllers/SGCreateFromMobileController.js
@@ -247,7 +247,6 @@ function ErrorAbortPromiseChain() {
  */
 SGCreateFromMobileController.prototype._updateDocument = function(configDoc) {
   var editedDoc = {
-      _id: configDoc._id,
       alpha_first_name: configDoc.alpha_first_name ? configDoc.alpha_first_name : null,
       beta_mobile_0: configDoc.beta_mobile_0 ? configDoc.beta_mobile_0 : null,
       beta_mobile_1: configDoc.beta_mobile_1 ? configDoc.beta_mobile_1 : null,

--- a/app/lib/sms-games/controllers/SGCreateFromMobileController.js
+++ b/app/lib/sms-games/controllers/SGCreateFromMobileController.js
@@ -65,11 +65,12 @@ SGCreateFromMobileController.prototype.processRequest = function(request, respon
     return false;
   }
 
-  // Query for an existing game creation config doc.
-  var queryConfig = configModel.findOne({alpha_mobile: request.body.phone});
+  // Query for the game creation config doc most recently created by this user.
+  var queryConfig = configModel.find({alpha_mobile: request.body.phone, story_id: request.query.story_id}).sort({created_at: -1}).limit(1);
   var promiseConfig = queryConfig.exec();
-  promiseConfig.then(function(configDoc) {
-    // If no document found, then create one. This game creation config doc 
+
+  promiseConfig.then(function(configDocs) {
+    // If no document has been created by this user, then create one. This game creation config doc 
     // should NOT be confused with the game doc, or the gameConfig. It's destroyed
     // after the game is begun; it's used only for game creation. 
     if (configDoc == null) {
@@ -128,7 +129,6 @@ SGCreateFromMobileController.prototype.processRequest = function(request, respon
       }
       // If the message contains a valid phone number and beta name. 
       else if (isPhoneNumber(message) && smsHelper.hasLetters(message)) {
-        debugger;
         var betaMobile = smsHelper.getNormalizedPhone(message);
         var betaName = smsHelper.getLetters(message);
 
@@ -152,7 +152,6 @@ SGCreateFromMobileController.prototype.processRequest = function(request, respon
         }
         // At this point, this is the last number we need. So, create the game.
         else {
-          debugger;
           configDoc.beta_mobile_2 = betaMobile;
           configDoc.beta_first_name_2 = betaName;
           // Again, while it may seem that the two calls below may produce async disorderlyness, they don't. 

--- a/app/lib/sms-games/controllers/SGCreateFromMobileController.js
+++ b/app/lib/sms-games/controllers/SGCreateFromMobileController.js
@@ -82,9 +82,11 @@ SGCreateFromMobileController.prototype.processRequest = function(request, respon
       var createGameConfig = configModel.create(doc);
       createGameConfig.then(function(doc) {
         emitter.emit('game-create-config-created', doc);
+        // @TODO: delete any existing create-game config docs for this user number and game ID. 
       })
       // Send next message asking for beta_mobile_1.
       sendSMS(request.body.phone, gameConfig.mobile_create.ask_beta_0_oip);
+
     }
     else {
       // If user responded with something else, ask for a valid player name. 

--- a/app/lib/sms-games/models/sgGameCreateConfig.js
+++ b/app/lib/sms-games/models/sgGameCreateConfig.js
@@ -36,7 +36,11 @@ var sgGameCreateConfigSchema = new mongoose.Schema({
   story_id: Number,
 
   // Type of game structure; competitive? collaborative?
-  story_type: String
+  story_type: String,
+
+  // Timestamp. 
+  created_at: {type: Date, default: Date.now}
+
 })
 
 module.exports = function(connection) {

--- a/test/CreateGameFromMobile.js
+++ b/test/CreateGameFromMobile.js
@@ -258,7 +258,6 @@ describe('Mobile-create-flow sends appropriate error messages', function() {
     }
     it('sends the alpha an error message', function(done) {
       emitter.on(emitter.events.mcOptinTest, function(payload) {
-        console.log(payload, '&&&&', gameConfig)
         if (payload.form.opt_in_path == gameConfig.mobile_create.invalid_alpha_first_name_oip) {
           done();
         }

--- a/test/CreateGameFromMobile.js
+++ b/test/CreateGameFromMobile.js
@@ -46,7 +46,8 @@ describe('Creating a four-player game with first names from mobile: ', function(
       var request = {
         query: {
           story_id: storyId,
-          story_type: storyType
+          story_type: storyType,
+          alpha_first_name_query_response: true
         },
         body: {
           phone: alphaPhone,
@@ -160,7 +161,8 @@ describe('Alpha creating a game through mobile after only inviting one player', 
     var request = {
       query: {
         story_id: storyId,
-        story_type: storyType
+        story_type: storyType,
+        alpha_first_name_query_response: true
       },
       body: {
         phone: alphaPhone,
@@ -240,38 +242,25 @@ describe('Alpha creating a game through mobile after only inviting one player', 
   })
 })
 
-// test a game creation process where the player first enter invalid params for 1) alpha name, 2) beta 0 namRitike, and 3) beta 0 number.
+// test a game creation process where the player first enter invalid params for 1) alpha name, 2) beta 0 name, and 3) beta 0 number.
 describe('Mobile-create-flow sends appropriate error messages', function() {
   describe(alphaName + ' beginning a mobile create flow and entering a number, not a name', function() {
     var request = {
       query: {
         story_id: storyId,
-        story_type: storyType
+        story_type: storyType,
+        alpha_first_name_query_response: true
       },
       body: {
         phone: alphaPhone,
         args: alphaPhone
       }
     }
-    it('sends the alpha an error message yet still creates a game-create-config doc', function(done) {
-
-      var eventsWaitedOn = 2;
-      var recordEvent = function() {
-        eventsWaitedOn --
-        if (eventsWaitedOn === 0) {
-          done();
-        }
-      }
-
-      emitter.on('game-create-config-created', function(doc) {
-        gameCreateConfigId = doc._id;
-        emitter.removeAllListeners('game-create-config-created');
-        recordEvent();
-      })
-
+    it('sends the alpha an error message', function(done) {
       emitter.on(emitter.events.mcOptinTest, function(payload) {
-        if (payload.form.opt_in_path == gameConfig.mobile_create.invalid_alpha_first_name) {
-          recordEvent();
+        console.log(payload, '&&&&', gameConfig)
+        if (payload.form.opt_in_path == gameConfig.mobile_create.invalid_alpha_first_name_oip) {
+          done();
         }
         else {
           assert(false);
@@ -286,23 +275,28 @@ describe('Mobile-create-flow sends appropriate error messages', function() {
     var request = {
       query: {
         story_id: storyId,
-        story_type: storyType
+        story_type: storyType,
+        alpha_first_name_query_response: true
       },
       body: {
         phone: alphaPhone,
         args: alphaName
       }
     }
-    it('should update the game-create-config game doc', function(done) {
-      emitter.on('game-create-config-modified', function(doc) {
+    it('should create the game-create-config game doc', function(done) {
+
+      emitter.on('game-create-config-created', function(doc) {
+        gameCreateConfigId = doc._id;
+
         if (doc.alpha_first_name == alphaName && doc.alpha_first_name == alphaName) {
           done();
         }
         else {
           assert(false);
         }
-        emitter.removeAllListeners('game-create-config-modified');
+        emitter.removeAllListeners('game-create-config-created');
       })
+
       mobileController.processRequest(request, response);
     })
   })


### PR DESCRIPTION
#### What's this PR do?
This PR adds a bug fix. (See details of the bug below.) We fix this by: 

1. Adding a timestamp to game create config documents, and querying only for the most recent document. 
2. Creating [a new MData](https://dosomething.mcommons.com/mdatas/12211) with a new query param, `alpha_first_name_query_response`, to the mdata attached to [the first message of the mobile create flow](https://dosomething.mcommons.com/campaigns/135439/opt_in_paths/181501), as well as the ["invalid alpha first name"](https://dosomething.mcommons.com/campaigns/135439/opt_in_paths/181645) message.  
3. Checking for the presence of this query param within `SGCreateFromMobileController.prototype.processRequest` in order to determine whether or not a new game create config doc should be created. If it's present, then the user has just texted in their first name to the first message in the mobile create flow, and we create a new document. 
4. General refactoring and modification of tests. 

#### Where should the reviewer start?
`SGCreateFromMobileController.js`. 

#### How should this be manually tested?
Using Postman, begin the game creation mobile flow. Begin another game creation mobile flow with the same user phone number. Make sure that you can finish the second flow without interfering with the first flow. 

You can use [this postman collection](https://www.getpostman.com/collections/128ccf5f25ffd622572d) to test. 

#### Any background context you want to provide?
Previously, when a user creates a game from mobile, is brought into another flow, and then begins to create another game from mobile, the flow of messages returned is off. 

This is because the first game-create-config doc created when the user first creates a game from mobile is never deleted. When the user texts back again, that same doc is found and updated by the user's responses. This creates problems. 

Let me give you an example: 

User texts in `Tong` to create the first game from mobile, creating the following game config doc: 

```
{ _id: 55ca758920ddda069cb3534c,
  alpha_mobile: '15555550479',
  story_id: 400,
  story_type: 'competitive-story',
  alpha_first_name: 'Tong',
  __v: 0,
  beta_mobile_0: null,
  beta_mobile_1: null,
  beta_mobile_2: null,
  beta_first_name_0: '',
  beta_first_name_1: '',
  beta_first_name_2: '',
  created_at: Tue Aug 11 2015 18:22:01 GMT-0400 (EDT) }
```
When the user texts back in attempting to create a second mobile flow, the previous game create config doc is discovered because the query in `SGCreateFromMobileController.js` - `.processRequest()` previously searched for any documents with that user's phone number. 

So when that user texts back in with `Tong`, attempting to create another first game from mobile, our flow in `SGCreateFromMobileController` queries for the user doc belonging to Tong's number, and the flow discovers that the `alpha_first_name` param is already occupied. It attempts to place the new `Tong` input as being meant for `beta_mobile_0`, but since `Tong` doesn't include a number, the control flow sends an error message that the alpha has not properly texted back a valid beta name and number. 

#### What are the relevant tickets?
Closes #483. 