### PR TITLE
add project created by time limit to donorschoose search

### DIFF
--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -33,7 +33,8 @@ var TYPE_OF_LOCATION_WE_ARE_QUERYING_FOR = 'zip' // 'zip' or 'state'. Our retrie
   , DONATION_AMOUNT = 10
   , COST_TO_COMPLETE_UPPER_LIMIT = 10000
   , DONATE_API_URL = donorsChooseDonationBaseURL + donorsChooseApiKey
-  , DONATION_LOCATION = 'MN' // for Minnesota;
+  , DONATION_LOCATION = 'MN' // for Minnesota
+  , PROJECT_CREATION_CUTOFF_DATE = 1442188860000 // September 14th, 12:01 AM GMT
   , END_MESSAGE_DELAY = 2500; 
 
 var Q = require('q')
@@ -138,9 +139,10 @@ DonorsChooseDonationController.prototype.findProject = function(mobileNumber, co
   var urgencySort = 'sortBy=0'; 
   // Constrains results which fall within a specific 'costToComplete' value range. 
   var costToCompleteRange = 'costToCompleteRange=' + DONATION_AMOUNT + '+TO+' + COST_TO_COMPLETE_UPPER_LIMIT; 
+  var projectsCreatedBy = 'olderThan=' + PROJECT_CREATION_CUTOFF_DATE;
   // Maximum number of results to return. 
   var maxNumberOfResults = '1';
-  var filterParams = locationFilter + '&' + subjectFilter + '&' + urgencySort + '&' + costToCompleteRange + '&';
+  var filterParams = locationFilter + '&' + subjectFilter + '&' + urgencySort + '&' + costToCompleteRange + '&' + projectsCreatedBy + '&';
   var requestUrlString = donorsChooseProposalsQueryBaseURL + filterParams + 'APIKey=' + donorsChooseApiKey + '&max=' + maxNumberOfResults;
 
   requestHttp.get(requestUrlString, function(error, response, data) {


### PR DESCRIPTION
#### What's this PR do?
Limits projects returned to by the DonorsChoose API just to those created before September 14th, 12:01am GMT. 

#### Where should the reviewer start?
N/A

#### How should this be manually tested?
How to test? You can switch out the PROJECT_CREATION_CUTOFF_DATE value for an earlier Unix epoch date. For instance, you can use the following value:
`PROJECT_CREATION_CUTOFF_DATE = 1440028860000 // August 20th`
If you switch the value out for a date early enough, you should start seeing projects being returned which were created earlier than that date. (Which I manually verified by going to the Donorschoose site, finding that project, and confirming that it was created earlier than the specified date.) 

#### What are the relevant tickets?
Closes #494. 