### PR TITLE
change user to become honoree in donation API call

### DIFF
--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -391,10 +391,9 @@ DonorsChooseDonationController.prototype.submitDonation = function(apiInfoObject
       'token': tokenData,
       'proposalId': proposalId,
       'amount': DONATION_AMOUNT,
-      'email': (donorInfoObject.donorEmail || defaultDonorsChooseTransactionEmail),
-      'first': donorInfoObject.donorFirstName, 
-      'last': 'a DoSomething.org member',
-      'salutation': donorInfoObject.donorFirstName + ', a DoSomething.org Member'
+      'email': defaultDonorsChooseTransactionEmail,
+      'honoreeEmail': donorInfoObject.donorEmail,
+      'honoreeFirst': donorInfoObject.donorFirstName,
     }};
 
     logger.info('Submitting donation with params:', donateParams);


### PR DESCRIPTION
### What does this PR do?
Changes the DonorsChoose API call to make the donation **on behalf of** the user, instead of creating a an account associated with that user's email address. 

### Background
Correspondence with DonorsChoose team: 
Along the lines of feedback… our operations team highlighted one potential sticking point for our donors, and I wanted to see if it’d be possible to tweak the mechanics of the program for the remainder of the program. When someone completes the game, the game currently asks them for their email address to share the teacher’s note—which then creates a new donor account for them in our database. We’re a little concerned that this could be a problem, since we’re not telling the users that we’ll be creating accounts for them on DonorsChoose.org. For those who don’t want to sign up for our site full-time, we don’t want them to be surprised by our email marketing down the line!
 
To that end, we think it’d be cleaner to place these donations in honor of the people who complete the game rather than create a new donor account.  If you scroll down the project donations page of our API docs, you’ll see a section for honoree parameters—would you be able to make that change?