### PR TITLE
Bumped version number to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ds-mdata-responder",
-  "version": "0.0.1-19",
+  "version": "1.0.0",
   "description": "Interface for interacting with DoSomething.org SMS experiences.",
   "dependencies": {
     "body-parser": "^1.9.2",


### PR DESCRIPTION
Closes #457 by bumping version number to 1.0.0, and before myself or anybody else jumps back into this repo to break things. Per [semver.org](http://semver.org/#how-do-i-know-when-to-release-100):
> If your software is being used in production, it should probably already be 1.0.0. If you have a stable API on which users have come to depend, you should be 1.0.0. If you’re worrying a lot about backwards compatibility, you should probably already be 1.0.0.

Looking to start using Gitflow releases moving forward for this repo. Per the [Gitflow release branching model](http://nvie.com/posts/a-successful-git-branching-model/#release-branches), this would be our order of operations:
* [x] This release branch `release-1.0.0` was started from `develop` and bumps the version number
* [ ] Merge `release-1.0.0` into `master`, via this pull request or command line via `git merge --no-ff`
* [ ] Tag `master` with a new `1.0.0` tag
* [ ] Checkout `develop` and merge `release-1.0.0` e.g. `git merge --no-ff release-1.0.0`
* [ ] Delete `release-1.0.0` branch 

Somewhere in here we'd deploy our changes to Heroku too... 🚒 🎆 🔥 