### PR TITLE
Include .env in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.env
 
 # npm
 node_modules


### PR DESCRIPTION
Closes #522. 

Running app locally with `heroku local` reads environment variables from a `.env` file. 

### to do
* [ ] Update [Setup](https://github.com/DoSomething/ds-mdata-responder/wiki/Setup) wiki with `heroku local` as an alternative setup