### PR TITLE
Removes NewRelic package

### DIFF
--- a/app.json
+++ b/app.json
@@ -45,11 +45,12 @@
     "MOBILECOMMONS_COMPANY_KEY": {
       "required": true
     },
+    // @see https://github.com/DoSomething/ds-mdata-responder/issues/518 
     "NEW_RELIC_APP_NAME": {
-      "required": true
+      "required": false
     },
     "NEWRELIC_LICENSE_KEY": {
-      "required": true
+      "required": false
     },
     "NODE_ENV": {
       "required": true

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "mocha-lcov-reporter": "0.0.1",
     "mongoose": "~3.8.8",
     "mysql": "2.1.x",
-    "newrelic": "^1.11.5",
     "node-request-retry": "^1.0.0",
     "path": "~0.4.9",
     "q": "^1.0.1",

--- a/server.js
+++ b/server.js
@@ -3,11 +3,6 @@ global.rootRequire = function(name) {
   return require(__dirname + '/' + name);
 }
 
-// Nodejitsu specifies NODE_ENV='production' by default
-if (process.env.NODE_ENV == 'production') {
-  require('newrelic');
-}
-
 var express = require('express')
   , path = require('path')
   , http = require('http')


### PR DESCRIPTION
#### What's this PR do?
Removes the `newrelic` package to cut down on some [New Relic messages](https://github.com/DoSomething/ds-mdata-responder/issues/518#issuecomment-233358812) we're seeing in production:
>  {"v":0,"level":10,"name":"newrelic","hostname":"Aarons-MacBook-Pro-2.local","pid":1029,"time":"2016-07-19T21:13:04.305Z","msg":"Not creating segment \"timers.setTimeout\" because no transaction was active","component":"tracer"}

#### How should this be reviewed?
Run `heroku local` before and after to verify this branch stops the `newrelic` logs.

#### Any background context you want to provide?
Deploying to prod will complete step 2 in #518 