### PR TITLE
Thor

### DIFF
--- a/app/lib/ds-content-api/index.js
+++ b/app/lib/ds-content-api/index.js
@@ -14,7 +14,7 @@ if (process.env.NODE_ENV == 'production') {
   BASE_URL = 'https://www.dosomething.org/api/' + VERSION;
 }
 else {
-  BASE_URL = 'http://staging.beta.dosomething.org/api/' + VERSION;
+  BASE_URL = 'https://thor.dosomething.org/api/' + VERSION;
 }
 
 module.exports = function() {

--- a/app/lib/reportback/index.js
+++ b/app/lib/reportback/index.js
@@ -20,7 +20,7 @@ if (process.env.NODE_ENV == 'production') {
   REPORTBACK_PERMALINK_BASE_URL = 'https://www.dosomething.org/reportback/';
 }
 else {
-  REPORTBACK_PERMALINK_BASE_URL = 'http://staging.beta.dosomething.org/reportback/';
+  REPORTBACK_PERMALINK_BASE_URL = 'https://thor.dosomething.org/reportback/';
 }
 
 /**

--- a/server.js
+++ b/server.js
@@ -13,13 +13,13 @@ var express = require('express')
 // Default is 5. Increasing # of concurrent sockets per host.
 http.globalAgent.maxSockets = 100;
 
-// Authenticate app with the DS content API.
+// Authenticate app with Phoenix API.
 dscontentapi.userLogin(
   process.env.DS_CONTENT_API_USERNAME,
   process.env.DS_CONTENT_API_PASSWORD,
   function(err, response, body) {
     if (response && response.statusCode == 200) {
-      logger.info('Successfully logged in to DS content API.',
+      logger.info('Successfully logged in to Phoenix API.',
         '\n\tsessid: ' + body.sessid,
         '\n\tsession_name: ' + body.session_name,
         '\n\ttoken: ' + body.token);


### PR DESCRIPTION
#### What's this PR do?
Changes test URLs to Phoenix-Thor instead of Phoenix-Staging.

#### How should this be reviewed?
We'll set up a new Mobile Commons campaign to post our Heroku staging app, `ds-mdata-responder-staging` with its own special test keyword. Once the campaign is live:
* [ ] text the keyword to us and complete the campaign
* [ ] verify your Reportback exists on Thor

#### Any background context you want to provide?
thor.dosomething.org has campaign and user id's that match production, staging.dosomething.org doesn't -- this should hopefully make testing our code easier, allowing us to test on existing `config` records with valid Mobile Commons campaign opt-in paths that match valid DoSomething campaigns (but authenticate against + report back to Thor)