### PR TITLE
Adds New Relic package

### DIFF
--- a/app.json
+++ b/app.json
@@ -51,6 +51,9 @@
     "NEW_RELIC_LICENSE_KEY": {
       "required": true
     },
+    "NEW_RELIC_LOGGING_LEVEL": {
+      "required": true
+    },
     "NODE_ENV": {
       "required": true
     },

--- a/app.json
+++ b/app.json
@@ -45,12 +45,11 @@
     "MOBILECOMMONS_COMPANY_KEY": {
       "required": true
     },
-    // @see https://github.com/DoSomething/ds-mdata-responder/issues/518 
     "NEW_RELIC_APP_NAME": {
-      "required": false
+      "required": true
     },
-    "NEWRELIC_LICENSE_KEY": {
-      "required": false
+    "NEW_RELIC_LICENSE_KEY": {
+      "required": true
     },
     "NODE_ENV": {
       "required": true

--- a/newrelic.js
+++ b/newrelic.js
@@ -1,0 +1,16 @@
+/**
+ * New Relic agent configuration.
+ *
+ */
+exports.config = {
+  app_name : [process.env.NEW_RELIC_APP_NAME],
+  license_key : process.env.NEW_RELIC_LICENSE_KEY,
+  logging : {
+    /**
+     * Level at which to log. 'trace' is most useful to New Relic when diagnosing
+     * issues with the agent, 'info' and higher will impose the least overhead on
+     * production applications.
+     */
+    level : process.env.NEW_RELIC_LOGGING_LEVEL
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "mocha-lcov-reporter": "0.0.1",
     "mongoose": "~3.8.8",
     "mysql": "2.1.x",
+    "newrelic": "^1.28.3",
     "node-request-retry": "^1.0.0",
     "path": "~0.4.9",
     "q": "^1.0.1",

--- a/server.js
+++ b/server.js
@@ -3,6 +3,11 @@ global.rootRequire = function(name) {
   return require(__dirname + '/' + name);
 }
 
+if (process.env.NODE_ENV == 'production' || process.env.NEW_RELIC_ENABLED) {
+  require ('newrelic');
+}
+
+
 var express = require('express')
   , path = require('path')
   , http = require('http')


### PR DESCRIPTION
Sorry, New Relic, it seems you [were noisy](https://github.com/DoSomething/ds-mdata-responder/issues/518#issuecomment-233358812) because we had our logging level set to `trace` this whole time. I've set you to `info` and things are looking a bit more peaceful ✌️ 

Refs discovery in https://github.com/DoSomething/ds-mdata-responder/pull/533#discussion_r71787107

My guess is when we first opened this issue for NO coverage, we were looking for New Relic coverage within our standard DS list of applications (prob what Nodejitsu was using), and not the Heroku add-on.

Dare I say this closes #518.

cc @mshmsh5000 