### PR TITLE
Removes hardcoded DonorsChoose olderThan param

### DIFF
--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -16,15 +16,13 @@
  *        submitDonation responsible for responding to user with success message
  */
 
-var donorsChooseApiKey = (process.env.DONORSCHOOSE_API_KEY || null)
-  , donorsChooseApiPassword = (process.env.DONORSCHOOSE_API_PASSWORD || null)
+var donorsChooseApiKey = (process.env.DONORSCHOOSE_API_KEY || 'DONORSCHOOSE')
+  , donorsChooseApiPassword = (process.env.DONORSCHOOSE_API_PASSWORD || 'helpClassrooms!')
   , donorsChooseDonationBaseURL = 'https://apisecure.donorschoose.org/common/json_api.html?APIKey='
   , donorsChooseProposalsQueryBaseURL = 'http://api.donorschoose.org/common/json_feed.html?'
   , defaultDonorsChooseTransactionEmail = (process.env.DONORSCHOOSE_DEFAULT_EMAIL || null);
 
 if (process.env.NODE_ENV == 'test') {
-  donorsChooseApiKey = 'DONORSCHOOSE';
-  donorsChooseApiPassword = 'helpClassrooms!';
   donorsChooseDonationBaseURL = 'https://dev1-apisecure.donorschoose.org/common/json_api.html?APIKey=';
 }
 
@@ -80,7 +78,6 @@ DonorsChooseDonationController.prototype.start = function(request, response) {
   phone = smsHelper.getNormalizedPhone(request.body.phone);
   configId = request.query.id;
   userModel.findOne({phone: phone}, onUserFound);
-
   response.send();
 
   // Callback after user is found
@@ -159,7 +156,6 @@ DonorsChooseDonationController.prototype.findProject = function(mobileNumber, co
       }
 
       if (selectedProposal) {
-
         var entities = new Entities(); // Calling 'html-entities' module to decode escaped characters.
         var location = entities.decode(selectedProposal.city) + ', ' + entities.decode(selectedProposal.state)
 
@@ -169,8 +165,8 @@ DonorsChooseDonationController.prototype.findProject = function(mobileNumber, co
           SS_school_name :          entities.decode(selectedProposal.schoolName),
           SS_proj_location:         location
         };
-
-      } else {
+      }
+      else {
         sendSMS(mobileNumber, config.error_direct_user_to_restart);
         logger.error('DonorsChoose API response for user mobile: ' + mobileNumber 
           + ' has not returned with a valid proposal. Response returned: ' 
@@ -193,6 +189,7 @@ DonorsChooseDonationController.prototype.findProject = function(mobileNumber, co
       // ensure that the ORIGINAL DOCUMENT IS CREATED before the user texts back 
       // their email address and attempts to find the document to be updated. 
       donationModel.create(currentDonationInfo).then(function(doc) {
+        logger.log('debug', 'DonorsChoose.findProject config:%s', JSON.stringify(config));
         mobilecommons.profile_update(mobileNumber, config.start_donation_flow, mobileCommonsCustomFields); // Arguments: phone, optInPathId, customFields.
         logger.info('Doc retrieved:', doc._id.toString(), ' - Updating Mobile Commons profile with:', mobileCommonsCustomFields);
       }, promiseErrorCallback('Unable to create donation document for user mobile: ' + mobileNumber));

--- a/mobilecommons/mobilecommons.js
+++ b/mobilecommons/mobilecommons.js
@@ -17,15 +17,21 @@ RequestRetry.setDefaults({timeout: 120000});
 * Mobile Commons profile_update API. Can be used to subscribe the user to an
 * opt-in path.
 *
+* @see https://mobilecommons.zendesk.com/hc/en-us/articles/202052534-REST-API#ProfileUpdate
+*
 * @param phone
 *   Phone number of the profile to update.
 * @param optInPathId
 *   Opt-in path to subscribe the user to.
 * @param customFields
-*   Array of custom profile field names and values to update the user with.
+*   Object with MoCo custom profile field names as properties, and values to update the user with.
+*   Note: Doesn't seem like the field names are case-sensitive. 
+*     e.g. SS_teacher_name and ss_teacher_name both update the same custom ss_teacher_name field
 */
 
 exports.profile_update = function(phone, optInPathId, customFields) {
+  logger.log('debug', 'mobilecommons.profile_update for user:%s oip:%s customFields:%s', phone, optInPathId, JSON.stringify(customFields));
+
   var url = 'https://secure.mcommons.com/api/profile_update';
   var authEmail = process.env.MOBILECOMMONS_AUTH_EMAIL;
   var authPass = process.env.MOBILECOMMONS_AUTH_PASS;


### PR DESCRIPTION
#### What's this PR do?
* Removes a hardcoded `olderThan=1445299201000` (Tue, 20 Oct 2015 00:00:01 GMT) query string param to get results back from the DonorsChoose API. Fixes #520, refs https://github.com/DoSomething/ds-mdata-responder/issues/539#issuecomment-236728667
* Adds `debug` logging to `DonorsChooseDonationController` and `mobilecommons.profile_update`

#### How should this be reviewed?
Run locally and POST to `http://localhost:5000/donations/donors-choose/start?id=201` with your phone number. You should receive a "Awesome we want [teacher name].." message back, instead of the "Oof! Something went wrong message".

Can additionally inspect queries in browser:
* [New request URL](http://api.donorschoose.org/common/json_feed.html?&subject4=-4&sortBy=2&costToCompleteRange=10+TO+10000&max=1&APIKey=DONORSCHOOSE)
* [Initial request URL (with olderThan)](http://api.donorschoose.org/common/json_feed.html?&subject4=-4&sortBy=2&costToCompleteRange=10+TO+10000&max=1&APIKey=DONORSCHOOSE&olderThan=1445299201000)

#### Any background context you want to provide?
I've been testing with configs `donorschoose` document id=201 for now, but we'll want to use id=301 once it has updated OIPs (refs #539)



cc @mshmsh5000 