### PR TITLE
DonorsChoose QA URL

### DIFF
--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -216,9 +216,11 @@ DonorsChooseDonationController.prototype.retrieveFirstName = function(request, r
   var config = app.getConfig(app.ConfigName.DONORSCHOOSE, request.query.id);
   var userSubmittedName = smsHelper.getFirstWord(request.body.args);
   var mobile = smsHelper.getNormalizedPhone(request.body.phone);
+  logger.log('debug', 'DonorsChoose.retrieveFirstName:%s for user:%s', userSubmittedName, mobile);
 
   if (stringValidator.containsNaughtyWords(userSubmittedName) || !userSubmittedName) {
     userSubmittedName = 'Anonymous';
+    logger.log('debug', 'DonorsChoose.retrieveFirstName set to %s for user:%s', userSubmittedName, mobile);
   }
 
   donationModel.findOneAndUpdate(


### PR DESCRIPTION
#### What's this PR do?
* Updates the DonorsChoose QA URL in attempt to fix #547.. but was getting a [statusCode 6](https://data.donorschoose.org/docs/transactions/project-donations/) when testing with QA credentials. Currently getting an error back that QA service is currently unavailable.
* Adds more `debug` logging to DonorsChoose flow
* Refactors `submitDonation` function to use already defined `donorsChooseApiKey`, `donorsChooseApiPassword`, and `DONATE_API_URL` variables instead of additional `apiInfoObject` object param

#### How should this be reviewed?
Test locally against the [Donations endpoints](https://github.com/DoSomething/ds-mdata-responder/wiki/api#donations) with`process.env.LOGGING_LEVEL = debug`  to confirm requests are being sent to updated URL per #547 

#### Any background context you want to provide?
Waiting to hear back from DonorsChoose team for guidance on the statusCode 6 error before merging.

