### PR TITLE
Changes new user emails to valid @mobile.import address

### DIFF
--- a/app/lib/ds-content-api/index.js
+++ b/app/lib/ds-content-api/index.js
@@ -88,7 +88,9 @@ function onUserCreate(err, response, body) {
   if (err) {
     logger.error('phoenix.userCreate error:', err);
   }
-
+  else {
+    logger.log('debug', 'phoenix.userCreate body:', JSON.stringify(body));
+  }
   if (typeof this.customCallback === 'function') {
     this.customCallback(err, response, body);
   }
@@ -98,7 +100,7 @@ function onUserCreate(err, response, body) {
  * Get user
  */
 function userGet(userData, callback) {
-  logger.log('debug', 'phoenix.userGet called with userData:%s', JSON.stringify(userData));
+  logger.log('debug', 'phoenix.userGet userData:%s', JSON.stringify(userData));
   var options = {
     url: BASE_URL + '/users',
     method: 'GET',
@@ -120,15 +122,17 @@ function userGet(userData, callback) {
   if (typeof callback === 'function') {
     _callback = onUserGet.bind({customCallback: callback});
   }
-  logger.log('debug', 'phoenix.userGet request options:%s', JSON.stringify(options));
+  logger.log('debug', 'phoenix.userGet GET:%s', options.url);
   request(options, _callback)
 }
 
 function onUserGet(err, response, body) {
   if (err) {
-    logger.error('phoenix.onUserGet error:%s', JSON.stringify(err));
+    logger.error('phoenix.onUserGet error:', err);
   }
-  logger.log('info', 'phoenix.onUserGet body:%s', JSON.stringify(body));
+  else {
+    logger.log('debug', 'phoenix.onUserGet body:', JSON.stringify(body));
+  }
   if (typeof this.customCallback === 'function') {
     this.customCallback(err, response, body);
   }
@@ -343,7 +347,10 @@ function isCampaignsReportbackError(response, body) {
  */
 function onCampaignsReportback(err, response, body) {
   if (err) {
-    logger.error(err);
+    logger.error('phoenix.onCampaignsReportback error:', err);
+  }
+  else {
+    logger.log('debug', 'phoenix.onCampaignsReportback body:', JSON.stringify(body));
   }
 
   if (isCampaignsReportbackError(response, body)) {

--- a/app/lib/ds-content-api/index.js
+++ b/app/lib/ds-content-api/index.js
@@ -80,13 +80,13 @@ function userCreate(createData, callback) {
   if (typeof callback === 'function') {
     _callback = onUserCreate.bind({customCallback: callback});
   }
-
+  logger.log('debug', 'phoenix.userCreate request options:%s', JSON.stringify(options));
   request(options, _callback);
 }
 
 function onUserCreate(err, response, body) {
   if (err) {
-    logger.error(err);
+    logger.error('phoenix.userCreate error:', err);
   }
 
   if (typeof this.customCallback === 'function') {
@@ -98,6 +98,7 @@ function onUserCreate(err, response, body) {
  * Get user
  */
 function userGet(userData, callback) {
+  logger.log('debug', 'phoenix.userGet called with userData:%s', JSON.stringify(userData));
   var options = {
     url: BASE_URL + '/users',
     method: 'GET',
@@ -119,15 +120,15 @@ function userGet(userData, callback) {
   if (typeof callback === 'function') {
     _callback = onUserGet.bind({customCallback: callback});
   }
-
+  logger.log('debug', 'phoenix.userGet request options:%s', JSON.stringify(options));
   request(options, _callback)
 }
 
 function onUserGet(err, response, body) {
   if (err) {
-    logger.error(err);
+    logger.error('phoenix.onUserGet error:%s', JSON.stringify(err));
   }
-
+  logger.log('info', 'phoenix.onUserGet body:%s', JSON.stringify(body));
   if (typeof this.customCallback === 'function') {
     this.customCallback(err, response, body);
   }

--- a/app/lib/reportback/index.js
+++ b/app/lib/reportback/index.js
@@ -292,12 +292,10 @@ function findUserUidThenReportBack(doc, data) {
     doc: doc,
     isInitialSearch: true
   };
-  logger.log('debug', 'reportback.findUserUidThenReportBack phoenix.userGet:%s', JSON.stringify(userData));
   phoenix.userGet(userData, onFindUserUid.bind(context));
 }
 
 function onFindUserUid(err, response, body) {
-  logger.log('debug', 'reportback.onFindUserUid response:%s body:%s', JSON.stringify(response), JSON.stringify(body));
   var context;
 
   // Variables bound to the callback
@@ -357,8 +355,6 @@ function createUserThenReportback(doc, data) {
   };
 
   phoenix.userCreate(userData, function(err, response, body) {
-    logger.log('debug', 'reportback.userCreate response:' + JSON.stringify(response));
-
     if (body && body.uid) {
       submitReportback(body.uid, doc, data);
     }
@@ -372,7 +368,7 @@ function createUserThenReportback(doc, data) {
  * Submit a report back.
  *
  * @param uid
- *   Numeric Phoenix user ID
+ *   Numeric Phoenix User uid
  * @param doc
  *   User's reportback document
  * @param data

--- a/app/lib/reportback/index.js
+++ b/app/lib/reportback/index.js
@@ -340,7 +340,7 @@ function onFindUserUid(err, response, body) {
  *   Data from the user's request
  */
 function createUserThenReportback(doc, data) {
-  var phone;
+  var phone = data.phone;
   var userData;
 
   // Strip the international code for user registration data

--- a/app/lib/reportback/index.js
+++ b/app/lib/reportback/index.js
@@ -349,7 +349,7 @@ function createUserThenReportBack(doc, data) {
   }
 
   userData = {
-    email: phone + '@mobile',
+    email: phone + '@mobile.import',
     mobile: phone,
     user_registration_source: process.env.DS_CONTENT_API_USER_REGISTRATION_SOURCE
   };

--- a/app/lib/reportback/index.js
+++ b/app/lib/reportback/index.js
@@ -274,7 +274,7 @@ function logReportbackStep(doc, data) {
  *   Data from the user's request
  */
 function findUserUidThenReportBack(doc, data) {
-  var phone;
+  var phone = data.phone;
   var userData;
   var context;
 

--- a/mobilecommons/mobilecommons.js
+++ b/mobilecommons/mobilecommons.js
@@ -65,12 +65,12 @@ exports.profile_update = function(phone, optInPathId, customFields) {
   var trace = new Error().stack;
   var callback = function(error, response, body) {
     if (error) {
-      logger.error('Failed mobilecommons.profile_update for user phone: '
+      logger.error('mobilecommons.profile_update for user:'
         + phone + ' | form data: ' + JSON.stringify(postData.form) 
         + ' | error: ' + error + ' | stack: ' + trace);
     }
     else if (response && response.statusCode != 200) {
-      logger.error('Failed mobilecommons.profile_update for user phone: '
+      logger.error('mobilecommons.profile_update for user:'
         + phone + ' | form data: ' + JSON.stringify(postData.form)
         + '| with code: ' + response.statusCode 
         + ' | body: ' + body + ' | stack: ' + trace);

--- a/mobilecommons/mobilecommons.js
+++ b/mobilecommons/mobilecommons.js
@@ -149,20 +149,20 @@ exports.optin = function(args) {
   var trace = new Error().stack;
   callback = function(error, response, body) {
     if (error) {
-      logger.error('Failed mobilecommons.optin for user:' + alphaPhone
+      logger.error('mobilecommons.optin error user:' + alphaPhone
         + ' | with request payload: ' + JSON.stringify(payload)
         + ' | with error: ' + JSON.stringify(error)
         + ' | stack: ' + trace);
     }
     else if (response) {
       if (response.statusCode != 200) {
-        logger.error('Failed mobilecommons.optin for user:' + alphaPhone
+        logger.error('mobilecommons.optin failed user:' + alphaPhone
           + ' | with request payload: ' + JSON.stringify(payload)
           + ' | with code: ' + response.statusCode + ' | body: '
           + body + ' | stack: ' + trace);
       }
       else {
-        logger.info('Success mobilecommons.optin to oip:%d for user:%s', alphaOptin, alphaPhone);
+        logger.info('mobilecommons.optin success oip:%d user:%s', alphaOptin, alphaPhone);
       }
     }
   };
@@ -209,20 +209,20 @@ exports.optout = function(args) {
   var trace = new Error().stack;
   var callback = function(error, response, body) {
     if (error) {
-      logger.error('Failed mobilecommons.optout for user: ' + phone
+      logger.error('mobilecommons.optout error user: ' + phone
         + ' | with request payload: ' + JSON.stringify(payload.form)
         + ' | with error: ' + JSON.stringify(error)
         + ' | stack: ' + trace);
     }
     else if (response) {
       if (response.statusCode != 200) {
-        logger.error('Failed mobilecommons.optout for user: ' + phone
+        logger.error('mobilecommons.optout failed user: ' + phone
           + ' | with request payload: ' + JSON.stringify(payload.form)
           + ' | with code: ' + response.statusCode
           + ' | body: ' + body + ' | stack: ' + trace);
       }
       else {
-        logger.info('Success mobilecommons.optout from moco_campaign_id:' + campaignId + ' for user:' + phone);
+        logger.info('mobilecommons.optout success moco_campaign:' + campaignId + ' user:' + phone);
       }
     }
   };


### PR DESCRIPTION
#### What's this PR do?
* Changes email address for new users to `@mobile.import` to fix #557 
* Adds a whole lot of `logger.log('debug', messages)` to watch the Phoenix go by
* Sets default values for `phone` in `findUserUidThenReportBack` and `createUserThenReportback` 

#### How should this be reviewed?
* Pull down and submit a reportback by posting against local `reportback` endpoint with 2 **brand-new-to-DS** US phone numbers:
    * [x] Test one new account including the leading 1 for country code , as we expect from Mobile Commons
    * [x] Test one without, just in case of any funny stuff.

* Verify new users are created in Thor. They should have emails without the leading 1:, e.g. `2125555555@dosomething.org`

#### Any background context you want to provide?
From @DFurnes:
> The `dosomething_northstar` module automatically strips out `@@mobile` when forwarding to Northstar (so the user only has a phone number), so we’d probably want to update it to do the same for `@mobile.import`s.