### PR TITLE
Science Sleuth Donations: collect zip and filter Projects query

### DIFF
--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -314,7 +314,7 @@ DonorsChooseDonationController.prototype.retrieveEmail = function(request, respo
  */
 DonorsChooseDonationController.prototype.submitDonation = function(donorInfoObject, proposalId) {
   var donorPhone = donorInfoObject.donorPhoneNumber;
-  logger.log('debug', 'DonorsChoose.submitDonation user:%s info:%s proposal:%s', donorPhone, JSON.stringify(donorInfoObject), proposalId);
+  logger.log('debug', 'DonorsChoose.submitDonation user:%s amount:%s info:%s proposal:%s', donorPhone, DONATION_AMOUNT, JSON.stringify(donorInfoObject), proposalId);
 
   requestToken().then(requestDonation,
     promiseErrorCallback('Unable to successfully retrieve donation token from DonorsChoose.org API. User mobile: '

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -72,7 +72,7 @@ function DonorsChooseDonationController() {
 DonorsChooseDonationController.prototype.resourceName = 'donors-choose';
 
 /**
- * Optional method to start the donation flow. Validates that this user is
+ * Start the donation flow by validating that this user is
  * allowed to make a donation.
  *
  * @param request
@@ -119,7 +119,7 @@ DonorsChooseDonationController.prototype.start = function(request, response) {
 };
 
 /**
- * Queries DonorsChoose API to find a project and sends the
+ * Queries DonorsChoose API to find a STEM project by zip and sends the
  * project details back to the user.
  *
  * @see https://data.donorschoose.org/docs/project-listing/json-requests/
@@ -132,8 +132,8 @@ DonorsChooseDonationController.prototype.findProject = function(mobileNumber, zi
   requestUrlString += '&costToCompleteRange=' + DONATION_AMOUNT + '+TO+' + COST_TO_COMPLETE_UPPER_LIMIT; 
   requestUrlString += '&max=1';
   requestUrlString += '&zip=' + zip;
-  requestUrlString += '&APIKey=' + donorsChooseApiKey;
   logger.log('debug', 'DonorsChoose.findProject request:%s', requestUrlString);
+  requestUrlString += '&APIKey=' + donorsChooseApiKey;
 
   requestHttp.get(requestUrlString, function(error, response, data) {
     if (!error) {
@@ -447,7 +447,7 @@ DonorsChooseDonationController.prototype.submitDonation = function(donorInfoObje
 
     // Find previous donation history and increment the count if found
     for (i = 0; i < doc.donations.length; i++) {
-      logger.log('verbose', 'donorsChoose.incrementDonationCount i=', i);
+      logger.log('verbose', 'donorsChoose.incrementDonationCount i=' + i);
       if (doc.donations[i].config_id == donorsChooseConfig.moco_campaign) {
         logger.log('verbose', 'donorsChoose.incrementDonationCount oc.donations[i].config_id == donorsChooseConfig.moco_campaign');
         doc.donations[i].count += 1;
@@ -512,22 +512,24 @@ DonorsChooseDonationController.prototype.submitDonation = function(donorInfoObje
  * @param response
  *   Express Response object
  */
-DonorsChooseDonationController.prototype.retrieveLocation = function(request, response) {
+DonorsChooseDonationController.prototype.retrieveZip = function(request, response) {
   if (typeof request.body.phone === 'undefined' || typeof request.body.args === 'undefined') {
     response.status(406).send('Missing required params.');
     return;
   }
 
   response.send();
-  var phone = request.body.phone;
+  var mobile = request.body.phone;
   var zip = smsHelper.getFirstWord(request.body.args);
+  logger.log('debug', 'DonorsChoose.retrieveZip:%s for user:%s', zip, mobile);
+
 
   if (!stringValidator.isValidZip(zip)) {
-    mobilecommons.profile_update(phone, donorsChooseConfig.oip_invalid_zip);
-    logger.log('debug', 'DonorsChoose.retrieveLocation invalid zip:%s user:%s', zip, phone);
+    mobilecommons.profile_update(mobile, donorsChooseConfig.oip_invalid_zip);
+    logger.log('debug', 'DonorsChoose.retrieveZip invalid zip:%s user:%s', zip, mobile);
     return;
   }
-  this.findProject(phone, zip);
+  this.findProject(mobile, zip);
 };
 
 /**

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -114,7 +114,7 @@ DonorsChooseDonationController.prototype.start = function(request, response) {
       self.findProject(phone);
     }
     else {
-      sendSMS(phone, donorsChooseConfig.oip_max_donations);
+      mobilecommons.profile_update(phone, donorsChooseConfig.oip_max_donations);
     }
   }
 };
@@ -151,7 +151,7 @@ DonorsChooseDonationController.prototype.findProject = function(mobileNumber) {
         }    
       }
       catch (e) {
-        sendSMS(mobileNumber, donorsChooseConfig.oip_error);
+        mobilecommons.profile_update(mobileNumber, donorsChooseConfig.oip_error);
         // JSON.parse will throw a SyntaxError exception if data is not valid JSON
         logger.error('DonorsChoose.findProject invalid JSON data received from DonorsChoose API for user: ' 
           + mobileNumber + ' , or selected proposal does not contain necessary fields. Error: ' + e);
@@ -170,7 +170,7 @@ DonorsChooseDonationController.prototype.findProject = function(mobileNumber) {
         };
       }
       else {
-        sendSMS(mobileNumber, donorsChooseConfig.oip_error);
+        mobilecommons.profile_update(mobileNumber, donorsChooseConfig.oip_error);
         logger.error('DonorsChoose.findProject API response for user:' + mobileNumber 
           + ' has not returned with a valid proposal. response:'  + donorsChooseResponse);
         return;
@@ -196,7 +196,7 @@ DonorsChooseDonationController.prototype.findProject = function(mobileNumber) {
       }, promiseErrorCallback('DonorsChoose.findProject unable to create donation_infos document for user: ' + mobileNumber));
     }
     else {
-      sendSMS(mobileNumber, donorsChooseConfig.oip_error);
+      mobilecommons.profile_update(mobileNumber, donorsChooseConfig.oip_error);
       logger.error('DonorsChoose.findProject error for user:' + mobileNumber 
         + ' in retrieving proposal info from DonorsChoose or in uploading to MobileCommons custom fields: ' + error);
       return;
@@ -236,7 +236,7 @@ DonorsChooseDonationController.prototype.retrieveFirstName = function(request, r
       if (err) {
         logger.error('Error in retrieving first name of user for user mobile: ' 
           + req.body.phone + ' | Error: ' + err);
-        sendSMS(mobile, donorsChooseConfig.oip_error);
+        mobilecommons.profile_update(mobile, donorsChooseConfig.oip_error);
       }
       else {
         mobilecommons.profile_update(mobile, donorsChooseConfig.oip_ask_email, { SS_user_first_name: userSubmittedName });
@@ -279,7 +279,7 @@ DonorsChooseDonationController.prototype.retrieveEmail = function(request, respo
     function(err, donorDocument) {
       if (err) {
         logger.error('DonorsChoose.retrieveEmail error for user:' + mobile + ' in donationModel.findOneAndUpdate: ' + err);
-        sendSMS(mobile, donorsChooseConfig.oip_error);
+        mobilecommons.profile_update(mobile, donorsChooseConfig.oip_error);
       } 
       else if (donorDocument) {
         logger.log('debug', 'DonorsChoose.retrieveEmail donorDocument:%s: for user:%s', JSON.stringify(donorDocument), mobile);
@@ -287,7 +287,7 @@ DonorsChooseDonationController.prototype.retrieveEmail = function(request, respo
         // or our app hasn't found a proposal (aka project) and attached a 
         // project_id to the document, we opt the user back into the start donation flow.  
         if (!donorDocument.project_id) {
-          sendSMS(mobile, donorsChooseConfig.oip_error);
+          mobilecommons.profile_update(mobile, donorsChooseConfig.oip_error);
         }
         else {
           var donorInfoObject = {
@@ -346,17 +346,17 @@ DonorsChooseDonationController.prototype.submitDonation = function(donorInfoObje
           }
           else {
             logger.error('DonorsChoose.requestToken statusDescription!=success user:%s', donorPhone);
-            sendSMS(donorPhone, donorsChooseConfig.oip_error);
+            mobilecommons.profile_update(donorPhone, donorsChooseConfig.oip_error);
           }
         }
         catch (e) {
           logger.error('DonorsChoose.requestToken failed user:'  + donorPhone + ' error:' + JSON.stringify(error));
-          sendSMS(donorPhone, donorsChooseConfig.oip_error);
+          mobilecommons.profile_update(donorPhone, donorsChooseConfig.oip_error);
         }
       }
       else {
         deferred.reject('DonorsChoose.requestToken error user: ' + donorPhone + 'error: ' + JSON.stringify(err));
-        sendSMS(donorPhone, donorsChooseConfig.oip_error);
+        mobilecommons.profile_update(donorPhone, donorsChooseConfig.oip_error);
       }
     });
     return deferred.promise;
@@ -382,11 +382,11 @@ DonorsChooseDonationController.prototype.submitDonation = function(donorInfoObje
     requestHttp.post(DONATE_API_URL, donateParams, function(err, response, body) {
       if (err) {
         logger.error('DonorsChoose.requestDonation requestHttp error user:' + donorInfoObject.donorPhoneNumber + 'error: ' + err);
-        sendSMS(donorPhone,  donorsChooseConfig.oip_error);
+        mobilecommons.profile_update(donorPhone,  donorsChooseConfig.oip_error);
       }
       else if (response && response.statusCode != 200) {
         logger.error('DonorsChoose.requestDonation response.statusCode:%s for user:%s', response.statusCode, donorInfoObject.donorPhoneNumber);
-        sendSMS(donorPhone, donorsChooseConfig.oip_error);
+        mobilecommons.profile_update(donorPhone, donorsChooseConfig.oip_error);
       }
       else {
         try {
@@ -398,12 +398,12 @@ DonorsChooseDonationController.prototype.submitDonation = function(donorInfoObje
           }
           else {
             logger.error('DonorsChoose.requestDonation failed user:' + donorPhone + ' proposal:' + proposalId + ' body:', jsonBody);
-            sendSMS(donorPhone, donorsChooseConfig.oip_error);
+            mobilecommons.profile_update(donorPhone, donorsChooseConfig.oip_error);
           }
         }
         catch (e) {
           logger.error('DonorsChoose.requestDonation catch exception for user:%s e:%s', donorPhone, e.message);
-          sendSMS(donorPhone, donorsChooseConfig.oip_error);
+          mobilecommons.profile_update(donorPhone, donorsChooseConfig.oip_error);
         }
       }
     })
@@ -530,7 +530,7 @@ DonorsChooseDonationController.prototype.retrieveLocation = function(request, re
 
   if (TYPE_OF_LOCATION_WE_ARE_QUERYING_FOR == 'zip') {
     if (!stringValidator.isValidZip(location)) {
-      sendSMS(request.body.phone, config.invalid_zip_oip);
+      mobilecommons.profile_update(request.body.phone, config.invalid_zip_oip);
       logger.info('User ' + request.body.phone 
         + ' did not submit a valid zipcode in the DonorsChoose.org flow.');
       return;
@@ -538,7 +538,7 @@ DonorsChooseDonationController.prototype.retrieveLocation = function(request, re
   }
   else if (TYPE_OF_LOCATION_WE_ARE_QUERYING_FOR == 'state') {
     if (!stringValidator.isValidState(location)) {
-      sendSMS(request.body.phone, config.invalid_state_oip);
+      mobilecommons.profile_update(request.body.phone, config.invalid_state_oip);
       logger.info('User ' + request.body.phone 
         + ' did not submit a valid state abbreviation in the DonorsChoose.org flow.');
       return;
@@ -612,20 +612,8 @@ function promiseErrorCallback(message, userPhone) {
 function onPromiseErrorCallback(err) {
   if (err) {
     logger.error(this.message + '\n', err.stack);
-    sendSMS(this.userPhone, config.error_start_again)
+    mobilecommons.profile_update(this.userPhone, config.error_start_again)
   }
 }
-
-/**
- * Subscribe phone number to a Mobile Commons opt-in path.
- *
- * @param phone
- *  Phone number to subscribe.
- * @param oip
- *   Opt-in path to subscribe to.
- */
-function sendSMS(phone, oip) {
-  mobilecommons.profile_update(phone, oip);
-};
 
 module.exports = DonorsChooseDonationController;

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -480,7 +480,7 @@ DonorsChooseDonationController.prototype.submitDonation = function(donorInfoObje
    *   URL to the DonorsChoose project
    */
   function sendSuccessMessages(mobileNumber, projectUrl) {
-    logger.log('debug', 'DonorsChoose.sendSuccessMessages user:%s config:%s projectUrl%s', mobileNumber, projectUrl);
+    logger.log('debug', 'DonorsChoose.sendSuccessMessages user:%s projectUrl%s', mobileNumber, projectUrl);
 
     // First message user receives. 
     mobilecommons.profile_update(mobileNumber, donorsChooseConfig.oip_donation_complete_1);
@@ -589,7 +589,7 @@ function promiseErrorCallback(message, userPhone) {
 function onPromiseErrorCallback(err) {
   if (err) {
     logger.error(this.message + '\n', err.stack);
-    mobilecommons.profile_update(this.userPhone, config.error_start_again)
+    mobilecommons.profile_update(this.userPhone, donorsChooseConfig.error_start_again)
   }
 }
 

--- a/app/lib/donations/donations.js
+++ b/app/lib/donations/donations.js
@@ -15,8 +15,7 @@
 var express = require('express')
   , router = express.Router();
 
-var DonorsChoose = require('./controllers/DonorsChooseDonationController')
-  ;
+var DonorsChoose = require('./controllers/DonorsChooseDonationController');
 
 /**
  * Load the controller associated with the provided controller name.

--- a/app/lib/donations/donations.js
+++ b/app/lib/donations/donations.js
@@ -8,7 +8,6 @@
  *   function retrieveFirstName(request, response)
  *   function retrieveZip(request, response)
  *   function submitDonation(request, response)
- *   function setHost(hostname)
  * }
  */
 
@@ -50,8 +49,7 @@ function implementsInterface(controller) {
       typeof controller.retrieveEmail === 'function' &&
       typeof controller.retrieveFirstName === 'function' &&
       typeof controller.retrieveZip === 'function' &&
-      typeof controller.submitDonation === 'function' &&
-      typeof controller.setHost === 'function') {
+      typeof controller.submitDonation === 'function') {
     return true;
   }
   else {
@@ -74,21 +72,9 @@ router.post('/:controller/start', function(request, response) {
   }
 });
 
-router.post('/:controller/find-project', function(request, response) {
-  var controller = loadController(request.params.controller);
-  if (controller) {
-    controller.setHost(request.get('host'));
-    controller.findProject(request, response);
-  }
-  else {
-    response.status(404).send('Request not available for: ' + request.params.controller);
-  }
-});
-
 router.post('/:controller/retrieve-email', function(request, response) {
   var controller = loadController(request.params.controller);
   if (controller) {
-    controller.setHost(request.get('host'));
     controller.retrieveEmail(request, response);
   }
   else {
@@ -99,7 +85,6 @@ router.post('/:controller/retrieve-email', function(request, response) {
 router.post('/:controller/retrieve-firstname', function(request, response) {
   var controller = loadController(request.params.controller);
   if (controller) {
-    controller.setHost(request.get('host'));
     controller.retrieveFirstName(request, response);
   }
   else {
@@ -110,7 +95,6 @@ router.post('/:controller/retrieve-firstname', function(request, response) {
 router.post('/:controller/retrieve-zip', function(request, response) {
   var controller = loadController(request.params.controller);
   if (controller) {
-    controller.setHost(request.get('host'));
     controller.retrieveZip(request, response);
   }
   else {

--- a/app/lib/donations/donations.js
+++ b/app/lib/donations/donations.js
@@ -6,7 +6,7 @@
  *   function findProject(request, response)
  *   function retrieveEmail(request, response)
  *   function retrieveFirstName(request, response)
- *   function retrieveLocation(request, response)
+ *   function retrieveZip(request, response)
  *   function submitDonation(request, response)
  *   function setHost(hostname)
  * }
@@ -49,7 +49,7 @@ function implementsInterface(controller) {
       typeof controller.findProject === 'function' &&
       typeof controller.retrieveEmail === 'function' &&
       typeof controller.retrieveFirstName === 'function' &&
-      typeof controller.retrieveLocation === 'function' &&
+      typeof controller.retrieveZip === 'function' &&
       typeof controller.submitDonation === 'function' &&
       typeof controller.setHost === 'function') {
     return true;
@@ -107,11 +107,11 @@ router.post('/:controller/retrieve-firstname', function(request, response) {
   }
 });
 
-router.post('/:controller/retrieve-location', function(request, response) {
+router.post('/:controller/retrieve-zip', function(request, response) {
   var controller = loadController(request.params.controller);
   if (controller) {
     controller.setHost(request.get('host'));
-    controller.retrieveLocation(request, response);
+    controller.retrieveZip(request, response);
   }
   else {
     response.status(404).send('Request not available for: ' + request.params.controller);


### PR DESCRIPTION
#### What's this PR do?
* Closes #566: Renames `retrieveLocation` function as `retrieveZip`, and changes it to call `findProject` with new param for `zip` to filter projects query by (instead of posting to itself with the `_post` function).
* Removes deprecated `/donations/donors-choose/find-projects` route and related `DonorsChooseDonationController.post()` function and `DonorsChooseDonationController.host` property
* Removes deprecated retrieve projects by state functionality. Less code, less moving parts
* Changes the `start` function to opt user into the `oip_ask_zip` if `max_donations_allowed` has not been reached. Previously the `start` function would simply call `findProject` without filtering for zip.
* For now, uses a hardcoded `donorsChooseConfig` variable to DRY instead of constantly reading calling `app.getConfig` in every function. Also stores donation count against the MoCo Campaign ID instead of the `config_id`. See todos section
    * Renames properties with `oip_` prefix
* Replaces the `sendSMS` helper function with the `mobilecommons.profile_update` function it calls, to better indicate how all this stuff works

#### How should this be reviewed?
Pull down and POST to the following endpoints on your localhost in this order (using your mobile number as a `phone` body parameter to verify correct messages sent back from MoCo), and confirming that zip code is collected and the selected project is filtered accordingly:
* `/donations/donors-choose/start`
* `/donations/donors-choose/retrieve-zip`
* `/donations/donors-choose/retrieve-firstname`
* `/donations/donors-choose/retrieve-email`

#### Any background context you want to provide?
Hardcoded the `donorsChooseConfig` oip's to avoid making changes to `donorschooseConfigModel.js` for right now. 2014 and 2015 both had different schema, 2016 now needs an Invalid Zip OIP which was missing from the file (removed in 2015):

<img width="690" alt="2014 vs 2015" src="https://cloud.githubusercontent.com/assets/1236811/17536482/163bbcde-5e4a-11e6-9172-da897ac9f604.png">

I'm not really sold on staying with `config` documents for these, as the ID's 101 and 201 are just arbitrarily chosen as far as I can tell. It seems logical to use the Moco Campaign ID instead. I've been toying with the idea of storing the actual message copy in the `donorsChooseConfig ` object instead of opt-in-paths, and saving the relevant response to a custom field like we do in the `/slothbot/mobilecommons` endpoint (#537). e.g `msg_invalid_zip`, `msg_ask_email` and storing to a `ss_response` Custom Field in Mobile Commons.

#### todo
* [ ] Resolve hardcoded opt-in paths, either sticking with the `config` documents and updating our `donorschooseConfigModel` accordingly, or setting as environment variables instead
    * [ ] Create clone of MoCo Donation 2016 campaign and mData's to have staging/production
    * [ ] Store user donations by `config_id` or MoCo Campaign ID based on decision
* [ ] Add checks for `request.data.phone` and `request.data.args` when applicable in each endpoint
* [ ] Update API documentation for `retrieve-zip` endpoint
* [ ] Update [ServerConfig:DonorsChoose](https://github.com/DoSomething/ServerConfig/wiki/4.2-DonorsChoose) to document the endpoints 2015 mData's pointed to (i've overwritten them because we will never use them again, and have 191 mData's in MoCo - majority exist never to be used again)